### PR TITLE
Introduce Float alias for precision control

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,5 +53,5 @@ int main(int argc, char** argv) {
   spdlog::info("Primitive count: {}", primitive_count);
   spdlog::info("Ray count: {}", rays);
   spdlog::info("kRays/s: {}",
-               static_cast<double>(rays) / 1'000 / duration.count());
+               static_cast<Float>(rays) / 1'000 / duration.count());
 }

--- a/src/tracer/aggregator.cpp
+++ b/src/tracer/aggregator.cpp
@@ -14,7 +14,7 @@ BVT::BVT(const std::vector<std::shared_ptr<Primitive>>& li) {
   bbox = root->GetBbox();
 }
 
-HitRecord BVT::Hit(const Ray& r, const Interval<double>& time_interval) const {
+HitRecord BVT::Hit(const Ray& r, const Interval<Float>& time_interval) const {
   return root->Hit(r, time_interval);
 }
 
@@ -27,7 +27,7 @@ inline static AABB _GetBbox(const BVT::Node::var_t& var) {
 }
 inline static HitRecord _GetHitResult(const BVT::Node::var_t& var,
                                       Ray r,
-                                      Interval<double> t) {
+                                      Interval<Float> t) {
   return std::visit(
       overload(
           [&](std::shared_ptr<BVT::Node> node) { return node->Hit(r, t); },
@@ -81,8 +81,8 @@ BVT::Node::Node(std::vector<std::shared_ptr<Primitive>>& src_obj,
   bbox = AABB{_GetBbox(lch), _GetBbox(rch)};
 }
 
-HitRecord BVT::Node::Hit(const Ray& r, const Interval<double>& time) const {
-  double closest_hit_time = time.end;
+HitRecord BVT::Node::Hit(const Ray& r, const Interval<Float>& time) const {
+  Float closest_hit_time = time.end;
 
   if (!bbox.isHitIn(r, time))
     return HitRecord();

--- a/src/tracer/aggregator.hpp
+++ b/src/tracer/aggregator.hpp
@@ -22,7 +22,7 @@ class BVT {
          size_t end,
          int axis = 0);
 
-    HitRecord Hit(const Ray&, const Interval<double>&) const;
+    HitRecord Hit(const Ray&, const Interval<Float>&) const;
     AABB GetBbox(void) const noexcept { return bbox; }
 
     using var_t =
@@ -35,7 +35,7 @@ class BVT {
   BVT(const std::vector<std::shared_ptr<Primitive>>& li);
 
   AABB GetBbox(void) const { return bbox; }
-  HitRecord Hit(const Ray&, const Interval<double>&) const;
+  HitRecord Hit(const Ray&, const Interval<Float>&) const;
 
  private:
   AABB bbox;

--- a/src/tracer/bsdf.cpp
+++ b/src/tracer/bsdf.cpp
@@ -34,7 +34,7 @@ std::optional<bxdfSample> BSDF::Sample_f(Vector3 wi) const {
   return std::nullopt;
 }
 
-double BSDF::pdf(Vector3 wi, Vector3 wo, BxDFBits flag) const {
+Float BSDF::pdf(Vector3 wi, Vector3 wo, BxDFBits flag) const {
   wi = transform.Doit(wi).Normalized();
   wo = transform.Doit(wo).Normalized();
   if (bxdf_ != nullptr && bxdf_->MatchesFlag(flag))

--- a/src/tracer/bsdf.hpp
+++ b/src/tracer/bsdf.hpp
@@ -37,7 +37,7 @@ class BxDF;
 struct bxdfSample {
   Color f;
   Vector3 wo;
-  double pdf;
+  Float pdf;
   BxDFBits flag;
 };
 
@@ -56,7 +56,7 @@ class BxDF {
 
   // returns the value of the probability density function for the given pair of
   // directions
-  virtual double pdf(const Vector3& wi, const Vector3& wo) const = 0;
+  virtual Float pdf(const Vector3& wi, const Vector3& wo) const = 0;
 
   bool MatchesFlag(BxDFBits flag) const {
     return (this->flag & flag) != BxDFBits::None;
@@ -82,7 +82,7 @@ class BSDF {
 
   Color f(Vector3 wi, Vector3 wo, BxDFBits flag = BxDFBits::All) const;
   std::optional<bxdfSample> Sample_f(Vector3 wi) const;
-  double pdf(Vector3 wi, Vector3 wo, BxDFBits flag = BxDFBits::All) const;
+  Float pdf(Vector3 wi, Vector3 wo, BxDFBits flag = BxDFBits::All) const;
   bool MatchesFlag(BxDFBits flag) const;
 
  private:

--- a/src/tracer/bxdfs/conductor.cpp
+++ b/src/tracer/bxdfs/conductor.cpp
@@ -22,16 +22,16 @@ Color Conductor::f(const Vector3& wi, const Vector3& wo) const {
     return Color(0);
 
   Vector3 wm = wo - wi;
-  double cos0_i = AbsCosTheta(wi), cos0_o = AbsCosTheta(wo);
+  Float cos0_i = AbsCosTheta(wi), cos0_o = AbsCosTheta(wo);
   if (cos0_i == 0 || cos0_o == 0 || wm.NearZero())
     return Color(0);
 
   wm = wm.Normalized();
-  double throughput = mfdist_.D(wm) * mfdist_.G(wi, wo) / (4 * cos0_i * cos0_o);
+  Float throughput = mfdist_.D(wm) * mfdist_.G(wi, wo) / (4 * cos0_i * cos0_o);
   return throughput * col_;
 }
 
-double Conductor::pdf(const Vector3& wi, const Vector3& wo) const {
+Float Conductor::pdf(const Vector3& wi, const Vector3& wo) const {
   if (mfdist_.EffectivelySmooth() || !SameHemisphere(wi, wo))
     return 0;
 
@@ -58,11 +58,11 @@ std::optional<bxdfSample> Conductor::Sample_f(const Vector3& wi) const {
   if (!SameHemisphere(wi, wo))
     return std::nullopt;
 
-  double costheta_i = AbsCosTheta(wi), costheta_o = AbsCosTheta(wo);
+  Float costheta_i = AbsCosTheta(wi), costheta_o = AbsCosTheta(wo);
   if (costheta_i == 0 || costheta_o == 0)
     return std::nullopt;
 
-  double pdf = mfdist_.PDF(wi, wm) / (4.0 * std::fabs(wi.Dot(wm)));
+  Float pdf = mfdist_.PDF(wi, wm) / (4.0 * std::fabs(wi.Dot(wm)));
   Color f = mfdist_.D(wm) * col_ * mfdist_.G(wi, wo) /
             (4.0 * costheta_i * costheta_o);
   return bxdfSample(f, wo, pdf, BxDFBits::Glossy | BxDFBits::Reflection);

--- a/src/tracer/bxdfs/conductor.hpp
+++ b/src/tracer/bxdfs/conductor.hpp
@@ -12,11 +12,11 @@ class Conductor : public BxDF {
 
   Color f(const Vector3& wi, const Vector3& wo) const override;
   std::optional<bxdfSample> Sample_f(const Vector3& wi) const override;
-  double pdf(const Vector3& wi, const Vector3& wo) const override;
+  Float pdf(const Vector3& wi, const Vector3& wo) const override;
 
  private:
   TrowbridgeReitzDistribution mfdist_;
-  double fuzz_;
+  Float fuzz_;
   Color col_;
 };
 

--- a/src/tracer/bxdfs/dielectric.cpp
+++ b/src/tracer/bxdfs/dielectric.cpp
@@ -7,8 +7,8 @@ using namespace vec_helpers;
 
 namespace {
 // helpers
-static double FrDielectric(double cos0, double eta) {
-  cos0 = std::clamp<double>(cos0, -1, 1);
+static Float FrDielectric(Float cos0, Float eta) {
+  cos0 = std::clamp<Float>(cos0, -1, 1);
   // Potentially flip interface orientation for Fresnel equations
   if (cos0 < 0) {
     eta = 1 / eta;
@@ -16,20 +16,20 @@ static double FrDielectric(double cos0, double eta) {
   }
 
   // Compute $\cos\,\theta_\roman{t}$ for Fresnel equations using Snell's law
-  double sin2Theta_o = 1 - Sqr(cos0);
-  double sin2Theta_t = sin2Theta_o / Sqr(eta);
+  Float sin2Theta_o = 1 - Sqr(cos0);
+  Float sin2Theta_t = sin2Theta_o / Sqr(eta);
   if (sin2Theta_t >= 1)
     return 1.f;
-  double cosTheta_t = std::sqrt(1 - sin2Theta_t);
+  Float cosTheta_t = std::sqrt(1 - sin2Theta_t);
 
-  double r_parl = (eta * cos0 - cosTheta_t) / (eta * cos0 + cosTheta_t);
-  double r_perp = (cos0 - eta * cosTheta_t) / (cos0 + eta * cosTheta_t);
+  Float r_parl = (eta * cos0 - cosTheta_t) / (eta * cos0 + cosTheta_t);
+  Float r_perp = (cos0 - eta * cosTheta_t) / (cos0 + eta * cosTheta_t);
   return (Sqr(r_parl) + Sqr(r_perp)) / 2;
 }
 
 }  // namespace
 
-Dielectric::Dielectric(double index, TrowbridgeReitzDistribution mfdist)
+Dielectric::Dielectric(Float index, TrowbridgeReitzDistribution mfdist)
     : BxDF(BxDFBits::Transmission), eta(index), mfdist_(std::move(mfdist)) {
   if (eta != 1)
     SetFlags(GetFlags() | BxDFBits::Reflection);
@@ -41,10 +41,10 @@ Color Dielectric::f(const Vector3& wi, const Vector3& wo) const {
   if (mfdist_.EffectivelySmooth() || eta == 1)
     return Color(0);
 
-  double cos0_i = CosTheta(-wi), cos0_o = CosTheta(wo);
+  Float cos0_i = CosTheta(-wi), cos0_o = CosTheta(wo);
   bool is_reflect = cos0_i * cos0_o > 0;
 
-  double etap = 1;
+  Float etap = 1;
   if (!is_reflect)
     etap = cos0_i > 0 ? eta : (1.0 / eta);
 
@@ -57,14 +57,14 @@ Color Dielectric::f(const Vector3& wi, const Vector3& wo) const {
   if (wm.Dot(wo) * cos0_o < 0 || wm.Dot(-wi) * cos0_i < 0)
     return Color(0);
 
-  double F = FrDielectric(wm.Dot(-wi), eta);
+  Float F = FrDielectric(wm.Dot(-wi), eta);
   if (is_reflect) {
-    double c =
+    Float c =
         mfdist_.D(wm) * mfdist_.G(wi, wo) * F / std::abs(4 * cos0_i * cos0_o);
     return Color(c);
   } else {
-    double denom = Sqr(wm.Dot(wo) + wm.Dot(-wi) / etap) * cos0_i * cos0_o;
-    double ft = mfdist_.D(wm) * (1 - F) * mfdist_.G(wi, wo) *
+    Float denom = Sqr(wm.Dot(wo) + wm.Dot(-wi) / etap) * cos0_i * cos0_o;
+    Float ft = mfdist_.D(wm) * (1 - F) * mfdist_.G(wi, wo) *
                 std::abs(wm.Dot(wo) * wm.Dot(-wi) / denom);
 
     ft /= Sqr(etap);
@@ -72,14 +72,14 @@ Color Dielectric::f(const Vector3& wi, const Vector3& wo) const {
   }
 }
 
-double Dielectric::pdf(const Vector3& wi, const Vector3& wo) const {
+Float Dielectric::pdf(const Vector3& wi, const Vector3& wo) const {
   if (mfdist_.EffectivelySmooth() || eta == 1)
     return 0;
 
-  double cos0_i = CosTheta(-wi), cos0_o = CosTheta(wo);
+  Float cos0_i = CosTheta(-wi), cos0_o = CosTheta(wo);
   bool is_reflect = cos0_i * cos0_o > 0;
 
-  double etap = 1;
+  Float etap = 1;
   if (!is_reflect)
     etap = cos0_i > 0 ? eta : (1.0 / eta);
 
@@ -92,15 +92,15 @@ double Dielectric::pdf(const Vector3& wi, const Vector3& wo) const {
   if (wm.Dot(wo) * cos0_o < 0 || wm.Dot(-wi) * cos0_i < 0)
     return 0;
 
-  double pr = FrDielectric(wm.Dot(-wi), eta);
-  double pt = 1.0 - pr;
+  Float pr = FrDielectric(wm.Dot(-wi), eta);
+  Float pt = 1.0 - pr;
 
-  double pdf = 0;
+  Float pdf = 0;
   if (is_reflect) {
     pdf = pr * mfdist_.PDF(-wi, wm) / (4 * std::abs(wm.Dot(wi)));
   } else {
-    double denom = Sqr(wm.Dot(wo) + wm.Dot(-wi) / etap);
-    double dwm_dwo = std::abs(wm.Dot(wo)) / denom;
+    Float denom = Sqr(wm.Dot(wo) + wm.Dot(-wi) / etap);
+    Float dwm_dwo = std::abs(wm.Dot(wo)) / denom;
     pdf = mfdist_.PDF(-wi, wm) * dwm_dwo * pt;
   }
   return pdf;
@@ -108,13 +108,13 @@ double Dielectric::pdf(const Vector3& wi, const Vector3& wo) const {
 
 std::optional<bxdfSample> Dielectric::Sample_f(const Vector3& wi) const {
   bool entering = wi.y() < 0;
-  double etaI = entering ? 1.0 : eta;
-  double etaT = entering ? eta : 1.0;
-  double etaRel = etaI / etaT;
+  Float etaI = entering ? 1.0 : eta;
+  Float etaT = entering ? eta : 1.0;
+  Float etaRel = etaI / etaT;
 
   if (eta == 1 || mfdist_.EffectivelySmooth()) {
-    double pr = FrDielectric(CosTheta(-wi), eta);
-    double pt = 1 - pr;
+    Float pr = FrDielectric(CosTheta(-wi), eta);
+    Float pt = 1 - pr;
 
     if (random_uniform_01() < pr) {
       Vector3 wo(wi.x(), -wi.y(), wi.z());
@@ -133,31 +133,31 @@ std::optional<bxdfSample> Dielectric::Sample_f(const Vector3& wi) const {
     }
   } else {
     Vector3 wm = mfdist_.Sample_wm(-wi);
-    double pr = FrDielectric(wm.Dot(-wi), eta);
-    double pt = 1.0 - pr;
+    Float pr = FrDielectric(wm.Dot(-wi), eta);
+    Float pt = 1.0 - pr;
 
     if (random_uniform_01() < pr) {
       Vector3 wo = Reflect(wi, wm).Normalized();
       if (!SameHemisphere(wi, wo))
         return std::nullopt;
 
-      double pdf = mfdist_.PDF(-wi, wm) / (4 * std::abs(wm.Dot(wi))) * pr;
-      double f = mfdist_.D(wm) * mfdist_.G(wi, wo) * pr /
+      Float pdf = mfdist_.PDF(-wi, wm) / (4 * std::abs(wm.Dot(wi))) * pr;
+      Float f = mfdist_.D(wm) * mfdist_.G(wi, wo) * pr /
                  (4 * CosTheta(wo) * CosTheta(-wi));
       return bxdfSample(Color(f), wo, pdf,
                         BxDFBits::Glossy | BxDFBits::Reflection);
     } else {
       Vector3 wo;
-      double etap = etaRel;
+      Float etap = etaRel;
       bool ok = Refract(wi, wm, etap, &wo);
       if (!ok || SameHemisphere(wi, wo) || wo.y() == 0)
         return std::nullopt;
 
       wo = wo.Normalized();
-      double denom = Sqr(wm.Dot(wo) + wm.Dot(-wi) / etap);
-      double dwm_dwo = std::abs(wm.Dot(wo)) / denom;
-      double pdf = mfdist_.PDF(-wi, wm) * dwm_dwo * pt;
-      double ft = pt * mfdist_.D(wm) * mfdist_.G(wi, wo) / denom *
+      Float denom = Sqr(wm.Dot(wo) + wm.Dot(-wi) / etap);
+      Float dwm_dwo = std::abs(wm.Dot(wo)) / denom;
+      Float pdf = mfdist_.PDF(-wi, wm) * dwm_dwo * pt;
+      Float ft = pt * mfdist_.D(wm) * mfdist_.G(wi, wo) / denom *
                   std::abs(wm.Dot(wo) * wm.Dot(-wi) /
                            (AbsCosTheta(wo) * AbsCosTheta(wi)));
 

--- a/src/tracer/bxdfs/dielectric.hpp
+++ b/src/tracer/bxdfs/dielectric.hpp
@@ -9,15 +9,15 @@ namespace bxdfs {
 class Dielectric : public BxDF {
  public:
   explicit Dielectric(
-      double eta,
+      Float eta,
       TrowbridgeReitzDistribution mfdist = TrowbridgeReitzDistribution(0, 0));
 
   Color f(const Vector3& wi, const Vector3& wo) const override;
   std::optional<bxdfSample> Sample_f(const Vector3& wi) const override;
-  double pdf(const Vector3& wi, const Vector3& wo) const override;
+  Float pdf(const Vector3& wi, const Vector3& wo) const override;
 
  private:
-  double eta;
+  Float eta;
   TrowbridgeReitzDistribution mfdist_;
 };
 

--- a/src/tracer/bxdfs/lambertian.cpp
+++ b/src/tracer/bxdfs/lambertian.cpp
@@ -19,7 +19,7 @@ std::optional<bxdfSample> Lambertian::Sample_f(const Vector3& wi) const {
                     BxDFBits::Diffuse | BxDFBits::Reflection);
 }
 
-double Lambertian::pdf(const Vector3& wi, const Vector3& wo) const {
+Float Lambertian::pdf(const Vector3& wi, const Vector3& wo) const {
   if (!SameHemisphere(wi, wo))
     return 0;
   return std::fabs(wo.y()) * invpi;

--- a/src/tracer/bxdfs/lambertian.hpp
+++ b/src/tracer/bxdfs/lambertian.hpp
@@ -79,7 +79,7 @@ class Lambertian : public BxDF {
    * @param wo  Outgoing direction (unit vector).
    * @return PDF value.
    */
-  double pdf(const Vector3& wi, const Vector3& wo) const override;
+  Float pdf(const Vector3& wi, const Vector3& wo) const override;
 
  private:
   Color col;  ///< Surface albedo color \f$\rho\f$.

--- a/src/tracer/camera.cpp
+++ b/src/tracer/camera.cpp
@@ -11,7 +11,7 @@ Camera::View_Info Camera::initializeView() const {
   auto h = tan(theta / 2);
   view.viewport_height = 2 * h * view.focal_length;
   view.viewport_width = view.viewport_height *
-                        (static_cast<double>(image_width_) / image_height_);
+                        (static_cast<Float>(image_width_) / image_height_);
 
   // The camera coordinate frame basis vectors
   Vector3 w = (looking_at_ - camera_center_).Normalized();    // front

--- a/src/tracer/camera.hpp
+++ b/src/tracer/camera.hpp
@@ -8,8 +8,8 @@ class Camera {
   Camera(Point3 center = {},
          Point3 lookAt = {},
          int imageHeight = 1080,
-         double aspectRatio = 16.0 / 9.0,
-         double vFovDeg = 30.0) noexcept
+         Float aspectRatio = 16.0 / 9.0,
+         Float vFovDeg = 30.0) noexcept
       : camera_center_{std::move(center)},
         looking_at_{std::move(lookAt)},
         up_direction_{0, 1, 0},
@@ -27,11 +27,11 @@ class Camera {
   void setLookAt(Point3 la) noexcept { looking_at_ = std::move(la); }
   [[nodiscard]] Point3 lookAt() const noexcept { return looking_at_; }
 
-  void setAspectRatio(double ar) noexcept {
+  void setAspectRatio(Float ar) noexcept {
     aspect_ratio_ = ar;
     clampDimensions();
   }
-  [[nodiscard]] double aspectRatio() const noexcept { return aspect_ratio_; }
+  [[nodiscard]] Float aspectRatio() const noexcept { return aspect_ratio_; }
 
   void setImageHeight(int h) noexcept {
     image_height_ = h;
@@ -46,8 +46,8 @@ class Camera {
   [[nodiscard]] int imageWidth() const noexcept { return image_width_; }
 
   struct View_Info {
-    double focal_length;
-    double viewport_height, viewport_width;
+    Float focal_length;
+    Float viewport_height, viewport_width;
     Vector3 viewport_u, viewport_v;
     Vector3 pixel_delta_u, pixel_delta_v;
     Point3 viewport_upper_left;
@@ -64,7 +64,7 @@ class Camera {
   Point3 camera_center_;
   Point3 looking_at_;
   Vector3 up_direction_;
-  double aspect_ratio_;
+  Float aspect_ratio_;
   int image_height_, image_width_;
-  double view_angle_vertical_;
+  Float view_angle_vertical_;
 };

--- a/src/tracer/hit_record.hpp
+++ b/src/tracer/hit_record.hpp
@@ -10,12 +10,12 @@ struct HitRecord {
   // note: everythin in local coordinate system
   bool hits = false;
   Primitive const* primitive = nullptr;
-  double time;
+  Float time;
   Point3 position;
   Point2 uv;
   Normal normal;  // outward normal
 
-  static constexpr HitRecord Create(double time,
+  static constexpr HitRecord Create(Float time,
                                     Point3 pos,
                                     Point2 uv,
                                     Normal n) {

--- a/src/tracer/mapping.cpp
+++ b/src/tracer/mapping.cpp
@@ -11,10 +11,10 @@ SphericalMap::SphericalMap(std::shared_ptr<ITransformation> trans)
 
 Point2 SphericalMap::Map(Point3 p) const {
   Point3 pt = trans_->Undo(p);
-  double r = pt.Length();
+  Float r = pt.Length();
   assert(r > 0);
-  double phi = std::atan2(pt.z(), pt.x());
-  double cos0 = std::clamp<double>(pt.y() / r, -1, 1);
-  double theta = std::acos(cos0);
+  Float phi = std::atan2(pt.z(), pt.x());
+  Float cos0 = std::clamp<Float>(pt.y() / r, -1, 1);
+  Float theta = std::acos(cos0);
   return Point2(phi / (2 * pi) + 0.5, theta / pi);
 }

--- a/src/tracer/material.cpp
+++ b/src/tracer/material.cpp
@@ -22,13 +22,13 @@ BSDF DiffuseMaterial::GetBSDF(const HitRecord& rec) const {
 }
 
 // ------------------------------------------------------------------------------
-ConductorMaterial::ConductorMaterial(Color color, double uRough, double vRough)
+ConductorMaterial::ConductorMaterial(Color color, Float uRough, Float vRough)
     : ConductorMaterial(make_texture(color),
                         make_texture(uRough),
                         make_texture(vRough)) {}
 ConductorMaterial::ConductorMaterial(Texture<Color> c,
-                                     Texture<double> ur,
-                                     Texture<double> vr)
+                                     Texture<Float> ur,
+                                     Texture<Float> vr)
     : albedo_(std::move(c)),
       uRoughness_(std::move(ur)),
       vRoughness_(std::move(vr)) {}
@@ -43,19 +43,19 @@ BSDF ConductorMaterial::GetBSDF(const HitRecord& rec) const {
 }
 
 // ------------------------------------------------------------------------------
-DielectricMaterial::DielectricMaterial(double eta, double uRough, double vRough)
+DielectricMaterial::DielectricMaterial(Float eta, Float uRough, Float vRough)
     : DielectricMaterial(make_texture(eta),
                          make_texture(uRough),
                          make_texture(vRough)) {}
-DielectricMaterial::DielectricMaterial(Texture<double> eta,
-                                       Texture<double> uRough,
-                                       Texture<double> vRough)
+DielectricMaterial::DielectricMaterial(Texture<Float> eta,
+                                       Texture<Float> uRough,
+                                       Texture<Float> vRough)
     : eta_(std::move(eta)),
       uRoughness_(std::move(uRough)),
       vRoughness_(std::move(vRough)) {}
 
 BSDF DielectricMaterial::GetBSDF(const HitRecord& rec) const {
-  double eta = eta_->Evaluate(rec.uv);
+  Float eta = eta_->Evaluate(rec.uv);
   TrowbridgeReitzDistribution ggx(uRoughness_->Evaluate(rec.uv),
                                   vRoughness_->Evaluate(rec.uv));
   return BSDF(
@@ -66,7 +66,7 @@ BSDF DielectricMaterial::GetBSDF(const HitRecord& rec) const {
 // ------------------------------------------------------------------------------
 MixedMaterial::MixedMaterial(std::shared_ptr<IMaterial> first,
                              std::shared_ptr<IMaterial> second,
-                             double fac)
+                             Float fac)
     : first_(std::move(first)), second_(std::move(second)), fac_(fac) {}
 
 std::shared_ptr<IMaterial> MixedMaterial::Select() const {

--- a/src/tracer/material.hpp
+++ b/src/tracer/material.hpp
@@ -27,37 +27,37 @@ class DiffuseMaterial : public IMaterial {
 
 class ConductorMaterial : public IMaterial {
   Texture<Color> albedo_;
-  Texture<double> uRoughness_, vRoughness_;
+  Texture<Float> uRoughness_, vRoughness_;
 
  public:
-  ConductorMaterial(Color albedo, double uRough, double vRough);
+  ConductorMaterial(Color albedo, Float uRough, Float vRough);
   ConductorMaterial(Texture<Color> albedo,
-                    Texture<double> ur,
-                    Texture<double> vr);
+                    Texture<Float> ur,
+                    Texture<Float> vr);
 
   BSDF GetBSDF(const HitRecord& rec) const override;
 };
 
 class DielectricMaterial : public IMaterial {
-  Texture<double> eta_, uRoughness_, vRoughness_;
+  Texture<Float> eta_, uRoughness_, vRoughness_;
 
  public:
-  DielectricMaterial(double eta, double uRough, double vRough);
-  DielectricMaterial(Texture<double> eta,
-                     Texture<double> uRough,
-                     Texture<double> vRough);
+  DielectricMaterial(Float eta, Float uRough, Float vRough);
+  DielectricMaterial(Texture<Float> eta,
+                     Texture<Float> uRough,
+                     Texture<Float> vRough);
 
   BSDF GetBSDF(const HitRecord& rec) const override;
 };
 
 class MixedMaterial : public IMaterial {
   std::shared_ptr<IMaterial> first_, second_;
-  double fac_;  // at 0, use first_ entirely
+  Float fac_;  // at 0, use first_ entirely
 
  public:
   MixedMaterial(std::shared_ptr<IMaterial> first,
                 std::shared_ptr<IMaterial> second,
-                double fac);
+                Float fac);
 
   std::shared_ptr<IMaterial> Select() const;
 

--- a/src/tracer/primitive.cpp
+++ b/src/tracer/primitive.cpp
@@ -13,7 +13,7 @@ Primitive::Primitive(std::shared_ptr<IShape> shape,
                      std::shared_ptr<ILight> light)
     : shape_(shape), material_(mat), light_(light) {}
 
-HitRecord Primitive::Hit(Ray ray, Interval<double> t) const {
+HitRecord Primitive::Hit(Ray ray, Interval<Float> t) const {
   auto rec = shape_->Hit(ray, t);
   if (rec.hits) {
     rec.primitive = this;

--- a/src/tracer/primitive.hpp
+++ b/src/tracer/primitive.hpp
@@ -23,7 +23,7 @@ class Primitive {
                      std::shared_ptr<IMaterial> mat,
                      std::shared_ptr<ILight> light);
 
-  HitRecord Hit(Ray r, Interval<double> t) const;
+  HitRecord Hit(Ray r, Interval<Float> t) const;
   AABB GetBbox(void) const;
   Color Le(Ray r) const;
 

--- a/src/tracer/scene.cpp
+++ b/src/tracer/scene.cpp
@@ -7,7 +7,7 @@
 Scene::Scene(std::vector<std::shared_ptr<Primitive>> objs)
     : objs_(std::move(objs)), aggregator_(std::make_unique<BVT>(objs_)) {}
 
-HitRecord Scene::Hit(Ray r, Interval<double> time) const {
+HitRecord Scene::Hit(Ray r, Interval<Float> time) const {
   return aggregator_->Hit(r, time);
 }
 

--- a/src/tracer/scene.hpp
+++ b/src/tracer/scene.hpp
@@ -19,7 +19,7 @@ class Scene {
   Scene(Scene&&) noexcept = default;
   Scene& operator=(Scene&&) noexcept = default;
 
-  HitRecord Hit(Ray ray, Interval<double> interval) const;
+  HitRecord Hit(Ray ray, Interval<Float> interval) const;
   AABB GetBbox(void) const;
   void SetBackground(std::function<Color(Ray)> fn);
   Color Background(Ray ray) const;

--- a/src/tracer/scene_factory.cpp
+++ b/src/tracer/scene_factory.cpp
@@ -50,9 +50,9 @@ inline Point3 parse_point3(const json& arr,
                            std::size_t offset,
                            std::string_view ctx) {
   expect_array_size(arr, offset + 3, ctx);
-  return {expect_number<double>(arr[offset + 0], ctx),
-          expect_number<double>(arr[offset + 1], ctx),
-          expect_number<double>(arr[offset + 2], ctx)};
+  return {expect_number<Float>(arr[offset + 0], ctx),
+          expect_number<Float>(arr[offset + 1], ctx),
+          expect_number<Float>(arr[offset + 2], ctx)};
 }
 
 }  // namespace
@@ -65,8 +65,8 @@ Camera SceneFactory::parse_camera(const json& r) {
   Point3 center = parse_point3(r, 0, ctx);
   Point3 look_at = parse_point3(r, 3, ctx);
   int image_h = expect_number<int>(r[6], "camera.image_h");
-  double aspect = expect_number<double>(r[7], "camera.aspect");
-  double vFovDeg = expect_number<double>(r[8], "camera.vFovDeg");
+  Float aspect = expect_number<Float>(r[7], "camera.aspect");
+  Float vFovDeg = expect_number<Float>(r[8], "camera.vFovDeg");
 
   return Camera(center, look_at, image_h, aspect, vFovDeg);
 }
@@ -121,7 +121,7 @@ void SceneFactory::parse_textures(const json& array) {
 
     } else if (type_s == "float") {
       texture =
-          static_cast<Texture<double>>(make_texture(it.at("v").get<double>()));
+          static_cast<Texture<Float>>(make_texture(it.at("v").get<Float>()));
 
     } else if (type_s == "image") {
       std::filesystem::path path = it.at("path").get<std::string>();
@@ -153,8 +153,8 @@ void SceneFactory::parse_materials(const json& array) {
       Texture<Color> col = resolve_color_texture(it.at("albedo"));
       const json& v = it.at("rough");
       expect_array_size(v, 1, "conductor.rough");
-      Texture<double> uR = resolve_float_texture(v.at(0));
-      Texture<double> vR = uR;
+      Texture<Float> uR = resolve_float_texture(v.at(0));
+      Texture<Float> vR = uR;
       if (v.size() >= 2)
         vR = resolve_float_texture(v.at(1));
       mat = std::make_shared<ConductorMaterial>(std::move(col), std::move(uR),
@@ -165,11 +165,11 @@ void SceneFactory::parse_materials(const json& array) {
       mat = std::make_shared<DiffuseMaterial>(std::move(albedo));
 
     } else if (type_s == "dielectric") {
-      Texture<double> eta = resolve_float_texture(it.at("eta"));
+      Texture<Float> eta = resolve_float_texture(it.at("eta"));
       const json& v = it.at("rough");
       expect_array_size(v, 1, "dielectric.rough");
-      Texture<double> uR = resolve_float_texture(v.at(0));
-      Texture<double> vR = uR;
+      Texture<Float> uR = resolve_float_texture(v.at(0));
+      Texture<Float> vR = uR;
       mat = std::make_shared<DielectricMaterial>(std::move(eta), std::move(uR),
                                                  std::move(vR));
 
@@ -178,7 +178,7 @@ void SceneFactory::parse_materials(const json& array) {
       expect_array_size(v, 2, "mix.data");
       std::shared_ptr<IMaterial> mat1 = resolve_mat(v[0]),
                                  mat2 = resolve_mat(v[1]);
-      double fac = expect_number<double>(it.at("fac"), "mix.fac");
+      Float fac = expect_number<Float>(it.at("fac"), "mix.fac");
       mat = std::make_shared<MixedMaterial>(mat1, mat2, fac);
     } else {
       throw SCENE_ERROR(ctx, "unknown material type '" + type_s +
@@ -212,9 +212,9 @@ void SceneFactory::parse_lights(const json& array) {
     expect_array_size(v, 3, "light data");
 
     auto light = std::make_shared<Light>(
-        Color(expect_number<double>(v[0], "light.color[0]"),
-              expect_number<double>(v[1], "light.color[1]"),
-              expect_number<double>(v[2], "light.color[2]")));
+        Color(expect_number<Float>(v[0], "light.color[0]"),
+              expect_number<Float>(v[1], "light.color[1]"),
+              expect_number<Float>(v[2], "light.color[2]")));
 
     if (it.contains("name") && it["name"].is_string())
       light_map_[it["name"].get<std::string>()] = light;
@@ -253,7 +253,7 @@ void SceneFactory::parse_objects(const json& array) {
       expect_array_size(v, 4, "sphere data");
       add_object(
           MakePrimitive<Sphere>(mat, light, parse_point3(v, 0, "sphere.center"),
-                                expect_number<double>(v[3], "sphere.radius")));
+                                expect_number<Float>(v[3], "sphere.radius")));
 
     } else if (type_s == "plane") {
       expect_array_size(v, 9, "plane data");
@@ -302,7 +302,7 @@ void SceneFactory::parse_objects(const json& array) {
 }
 
 // ------------------------------------------------------------------------------
-std::shared_ptr<ITexture<double>> SceneFactory::resolve_float_texture(
+std::shared_ptr<ITexture<Float>> SceneFactory::resolve_float_texture(
     const json& r) {
   if (r.is_array())  // one number, float const
     return std::make_shared<FloatConst>(r.at(0));
@@ -323,7 +323,7 @@ std::shared_ptr<ITexture<double>> SceneFactory::resolve_float_texture(
     throw SCENE_ERROR("float-texture", "out of bounds: " + std::to_string(idx));
 
   try {
-    return std::any_cast<Texture<double>>(textures_[idx]);
+    return std::any_cast<Texture<Float>>(textures_[idx]);
   } catch (std::bad_any_cast& e) {
     throw SCENE_ERROR("float-texture", "texture type is not float");
   }

--- a/src/tracer/scene_factory.hpp
+++ b/src/tracer/scene_factory.hpp
@@ -53,7 +53,7 @@ class SceneFactory {
 
   std::shared_ptr<IMaterial> resolve_mat(const json& m);
   std::shared_ptr<ILight> resolve_light(const json& l);
-  std::shared_ptr<ITexture<double>> resolve_float_texture(const json& r);
+  std::shared_ptr<ITexture<Float>> resolve_float_texture(const json& r);
   std::shared_ptr<ITexture<Color>> resolve_color_texture(const json& r);
 
  private:

--- a/src/tracer/shape.cpp
+++ b/src/tracer/shape.cpp
@@ -1,6 +1,6 @@
 #include "shape.hpp"
 
-double IShape::Area() const { return 0; }
+Float IShape::Area() const { return 0; }
 
 ShapeSample IShape::Sample() const {
   ShapeSample sample;
@@ -8,17 +8,17 @@ ShapeSample IShape::Sample() const {
   return sample;
 }
 
-double IShape::Pdf(Point3 ref, Vector3 wo) const {
-  const double area = Area();
+Float IShape::Pdf(Point3 ref, Vector3 wo) const {
+  const Float area = Area();
   if (area <= 0)
     return 0;
 
-  HitRecord rec = Hit(Ray(ref, wo), Interval<double>::Positive());
+  HitRecord rec = Hit(Ray(ref, wo), Interval<Float>::Positive());
   if (!rec.hits)
     return 0;
 
-  const double d2 = (rec.position - ref).Length_squared();
-  const double cos = std::fabs(Vector3::Dot(rec.normal, wo));
+  const Float d2 = (rec.position - ref).Length_squared();
+  const Float cos = std::fabs(Vector3::Dot(rec.normal, wo));
 
   return (1.0 / area) * d2 / cos;
 }

--- a/src/tracer/shape.hpp
+++ b/src/tracer/shape.hpp
@@ -13,18 +13,18 @@ class Primitive;
 struct ShapeSample {
   Point3 pos;
   Normal normal;
-  double pdf;
+  Float pdf;
 };
 
 class IShape {
  public:
   virtual ~IShape() = default;
 
-  virtual HitRecord Hit(const Ray&, const Interval<double>&) const = 0;
+  virtual HitRecord Hit(const Ray&, const Interval<Float>&) const = 0;
   virtual AABB GetBbox() const = 0;
 
-  virtual double Area() const;
+  virtual Float Area() const;
   virtual ShapeSample Sample() const;
 
-  double Pdf(Point3 ref, Vector3 wo) const;
+  Float Pdf(Point3 ref, Vector3 wo) const;
 };

--- a/src/tracer/shapes/2d/parallelogram.cpp
+++ b/src/tracer/shapes/2d/parallelogram.cpp
@@ -17,15 +17,15 @@ AABB Parallelogram::GetBbox() const {
   return box.Transform(trans_);
 }
 
-inline static auto OnObject(double a, double b) {
+inline static auto OnObject(Float a, Float b) {
   return 0 <= a && a <= 1 && 0 <= b && b <= 1;
 }
 
 HitRecord Parallelogram::Hit(const Ray& ray,
-                             const Interval<double>& time_interval) const {
+                             const Interval<Float>& time_interval) const {
   Ray r = ray.UndoTransform(trans_);
 
-  const double time = -r.Origin().y() / r.Direction().y();
+  const Float time = -r.Origin().y() / r.Direction().y();
   if (std::isnan(time))
     return HitRecord();
   if (!time_interval.Surrounds(time))
@@ -49,4 +49,4 @@ ShapeSample Parallelogram::Sample() const {
   return sample;
 }
 
-double Parallelogram::Area() const { return area_; }
+Float Parallelogram::Area() const { return area_; }

--- a/src/tracer/shapes/2d/parallelogram.hpp
+++ b/src/tracer/shapes/2d/parallelogram.hpp
@@ -12,11 +12,11 @@ class Parallelogram : public IShape {
   Parallelogram(Point3 o, Point3 a, Point3 b);
 
   AABB GetBbox() const override;
-  HitRecord Hit(const Ray&, const Interval<double>&) const override;
+  HitRecord Hit(const Ray&, const Interval<Float>&) const override;
   ShapeSample Sample() const override;
-  double Area() const override;
+  Float Area() const override;
 
  private:
   MatrixTransformation trans_;
-  double area_;
+  Float area_;
 };

--- a/src/tracer/shapes/2d/plane.cpp
+++ b/src/tracer/shapes/2d/plane.cpp
@@ -6,25 +6,25 @@ Plane ::Plane(Point3 o, Point3 a, Point3 b)
     : trans_(MatrixTransformation::ChangeCoordinate(o, a, b)) {}
 
 AABB Plane::GetBbox(void) const {
-  static const AABB box = AABB(Interval<double>::Universe(), Interval<double>(),
-                               Interval<double>::Universe())
+  static const AABB box = AABB(Interval<Float>::Universe(), Interval<Float>(),
+                               Interval<Float>::Universe())
                               .Pad();
   return box.Transform(trans_);
 }
 
 HitRecord Plane::Hit(const Ray& ray,
-                     const Interval<double>& time_interval) const {
+                     const Interval<Float>& time_interval) const {
   Ray r = ray.UndoTransform(trans_);
 
-  double time = -r.Origin().y() / r.Direction().y();
+  Float time = -r.Origin().y() / r.Direction().y();
   if (std::isnan(time))
     return HitRecord();
   if (!time_interval.Contains(time))
     return HitRecord();
 
   Point3 hit_point = r.At(time);
-  double u = hit_point.x();
-  double v = hit_point.z();
+  Float u = hit_point.x();
+  Float v = hit_point.z();
 
   static const Normal normal{0, 1, 0};
   return HitRecord::Create(time, ray.At(time),

--- a/src/tracer/shapes/2d/plane.hpp
+++ b/src/tracer/shapes/2d/plane.hpp
@@ -8,7 +8,7 @@ class Plane : public IShape {
 
   AABB GetBbox(void) const override;
   HitRecord Hit(const Ray& ray,
-                const Interval<double>& interval) const override;
+                const Interval<Float>& interval) const override;
 
  private:
   MatrixTransformation trans_;

--- a/src/tracer/shapes/2d/triangle.cpp
+++ b/src/tracer/shapes/2d/triangle.cpp
@@ -17,15 +17,15 @@ AABB Triangle::GetBbox() const {
   return box.Transform(trans_);
 }
 
-inline static auto OnObject(double a, double b) {
+inline static auto OnObject(Float a, Float b) {
   return (a + b) <= 1 && 0 <= a && 0 <= b;
 }
 
 HitRecord Triangle::Hit(const Ray& ray,
-                        const Interval<double>& time_interval) const {
+                        const Interval<Float>& time_interval) const {
   Ray r = ray.UndoTransform(trans_);
 
-  double time = -r.Origin().y() / r.Direction().y();
+  Float time = -r.Origin().y() / r.Direction().y();
   if (std::isnan(time))
     return HitRecord();
   if (!time_interval.Surrounds(time))
@@ -44,7 +44,7 @@ HitRecord Triangle::Hit(const Ray& ray,
 ShapeSample Triangle::Sample() const {
   ShapeSample sample;
   sample.pdf = 1.0 / area_;
-  double a = random_uniform_01(), b = random_uniform_01();
+  Float a = random_uniform_01(), b = random_uniform_01();
   if (!OnObject(a, b)) {
     a = 1 - a;
     b = 1 - b;
@@ -54,4 +54,4 @@ ShapeSample Triangle::Sample() const {
   return sample;
 }
 
-double Triangle::Area() const { return area_; }
+Float Triangle::Area() const { return area_; }

--- a/src/tracer/shapes/2d/triangle.hpp
+++ b/src/tracer/shapes/2d/triangle.hpp
@@ -7,11 +7,11 @@ class Triangle : public IShape {
   Triangle(Point3 o, Point3 a, Point3 b);
 
   AABB GetBbox() const override;
-  HitRecord Hit(const Ray&, const Interval<double>&) const override;
+  HitRecord Hit(const Ray&, const Interval<Float>&) const override;
   ShapeSample Sample() const override;
-  double Area() const override;
+  Float Area() const override;
 
  private:
   MatrixTransformation trans_;
-  double area_;
+  Float area_;
 };

--- a/src/tracer/shapes/3d/sphere.cpp
+++ b/src/tracer/shapes/3d/sphere.cpp
@@ -8,7 +8,7 @@
 #include <util/util.hpp>
 #include "spdlog/spdlog.h"
 
-Sphere::Sphere(Point3 o, double r)
+Sphere::Sphere(Point3 o, Float r)
     : trans_(o - Point3(0, 0, 0)),
       r_(r),
       bbox_(o + Vector3(r, r, r), o - Vector3(r, r, r)) {}
@@ -22,35 +22,35 @@ Point2 Sphere::GetUv(Point3 p) const {
                  p.y(), p.z(), p.Length());
 #endif
 
-  double phi = std::atan2(p.z(), p.x());
-  double cos0 = std::clamp<double>(p.y() / r_, -1, 1);
-  double theta = std::acos(cos0);
+  Float phi = std::atan2(p.z(), p.x());
+  Float cos0 = std::clamp<Float>(p.y() / r_, -1, 1);
+  Float theta = std::acos(cos0);
   return Point2(phi / (2 * pi) + 0.5, theta / pi);
 }
 
 HitRecord Sphere::Hit(const Ray& ray,
-                      const Interval<double>& time_interval) const {
+                      const Interval<Float>& time_interval) const {
   Ray r = ray.UndoTransform(trans_);
 
   Vector3 oc = (Vector3)r.Origin();
-  double a = r.Direction().Length_squared();
-  double b = Vector3::Dot(oc, r.Direction()) * 2;
-  double c = oc.Length_squared() - r_ * r_;
+  Float a = r.Direction().Length_squared();
+  Float b = Vector3::Dot(oc, r.Direction()) * 2;
+  Float c = oc.Length_squared() - r_ * r_;
 
-  double discriminant = b * b - 4 * a * c;
+  Float discriminant = b * b - 4 * a * c;
   if (discriminant < 0)
     return HitRecord();
-  double sqrtd = std::sqrt(discriminant);
+  Float sqrtd = std::sqrt(discriminant);
 
   // Find the nearest root that lies in the acceptable range.
-  double root = (-b - sqrtd) / (2 * a);
+  Float root = (-b - sqrtd) / (2 * a);
   if (!time_interval.Surrounds(root)) {
     root = (-b + sqrtd) / (2 * a);
     if (!time_interval.Surrounds(root))
       return HitRecord();
   }
 
-  double time = root;
+  Float time = root;
   Point3 position = r.At(time);
   Point2 uv = GetUv(position);
   Normal normal = Normal(position);
@@ -70,4 +70,4 @@ ShapeSample Sphere::Sample() const {
   return sample;
 }
 
-double Sphere::Area() const { return 4 * pi * Sqr(r_); }
+Float Sphere::Area() const { return 4 * pi * Sqr(r_); }

--- a/src/tracer/shapes/3d/sphere.hpp
+++ b/src/tracer/shapes/3d/sphere.hpp
@@ -5,14 +5,14 @@
 
 class Sphere : public IShape {
  public:
-  Sphere(Point3 o, double r);
+  Sphere(Point3 o, Float r);
 
   Point2 GetUv(Point3 p) const;
 
   AABB GetBbox(void) const override;
-  HitRecord Hit(const Ray& r, const Interval<double>& time) const override;
+  HitRecord Hit(const Ray& r, const Interval<Float>& time) const override;
   ShapeSample Sample() const override;
-  double Area() const override;
+  Float Area() const override;
 
   // for testing
   inline auto GetTransformation() const { return trans_; }
@@ -20,6 +20,6 @@ class Sphere : public IShape {
 
  private:
   VectorTranslate trans_;
-  double r_;
+  Float r_;
   AABB bbox_;
 };

--- a/src/tracer/texture.cpp
+++ b/src/tracer/texture.cpp
@@ -71,15 +71,15 @@ std::shared_ptr<ImageTexture> ImageTexture::Create(std::filesystem::path path) {
 }
 
 Color ImageTexture::Evaluate(Point2 uv) const {
-  double x = uv.x() * (w_ - 1);
-  double y = uv.y() * (h_ - 1);
+  Float x = uv.x() * (w_ - 1);
+  Float y = uv.y() * (h_ - 1);
 
   int x0 = int(x);
   int y0 = int(y);
   int x1 = std::min(x0 + 1, w_ - 1);
   int y1 = std::min(y0 + 1, h_ - 1);
-  double tx = x - x0;
-  double ty = y - y0;
+  Float tx = x - x0;
+  Float ty = y - y0;
 
   Color c00 = Texel(x0, y0);
   Color c10 = Texel(x1, y0);

--- a/src/tracer/texture.hpp
+++ b/src/tracer/texture.hpp
@@ -18,19 +18,19 @@ class SolidColor : public ITexture<Color> {
   Color col_;
 
  public:
-  SolidColor(double r, double g, double b) : SolidColor(Color(r, g, b)) {}
+  SolidColor(Float r, Float g, Float b) : SolidColor(Color(r, g, b)) {}
   SolidColor(Color col = {}) : col_(col) {}
 
   Color Evaluate(Point2) const override { return col_; }
 };
 
-class FloatConst : public ITexture<double> {
-  double val_;
+class FloatConst : public ITexture<Float> {
+  Float val_;
 
  public:
-  constexpr FloatConst(double v) : val_(v) {}
+  constexpr FloatConst(Float v) : val_(v) {}
 
-  double Evaluate(Point2) const override { return val_; }
+  Float Evaluate(Point2) const override { return val_; }
 };
 
 class ImageTexture : public ITexture<Color> {

--- a/src/tracer/trowbridge_reitz_distribution.cpp
+++ b/src/tracer/trowbridge_reitz_distribution.cpp
@@ -5,22 +5,22 @@
 
 using namespace vec_helpers;
 
-TrowbridgeReitzDistribution::TrowbridgeReitzDistribution(double ax, double az)
+TrowbridgeReitzDistribution::TrowbridgeReitzDistribution(Float ax, Float az)
     : alpha_x(ax), alpha_z(az) {
   if (!EffectivelySmooth()) {
-    alpha_x = std::max<double>(alpha_x, 1e-4);
-    alpha_z = std::max<double>(alpha_z, 1e-4);
+    alpha_x = std::max<Float>(alpha_x, 1e-4);
+    alpha_z = std::max<Float>(alpha_z, 1e-4);
   }
 }
 
-double TrowbridgeReitzDistribution::D(Vector3 wm) const {
-  double tan2Theta = Tan2Theta(wm);
+Float TrowbridgeReitzDistribution::D(Vector3 wm) const {
+  Float tan2Theta = Tan2Theta(wm);
   if (std::isinf(tan2Theta))
     return 0;
-  double cos4Theta = Sqr(Cos2Theta(wm));
+  Float cos4Theta = Sqr(Cos2Theta(wm));
   if (cos4Theta < 1e-16)
     return 0;
-  double e =
+  Float e =
       tan2Theta * (Sqr(CosPhi(wm) / alpha_z) + Sqr(SinPhi(wm) / alpha_x));
   return 1.0 / (pi * alpha_z * alpha_x * cos4Theta * Sqr(1 + e));
 }
@@ -29,28 +29,28 @@ bool TrowbridgeReitzDistribution::EffectivelySmooth() const {
   return alpha_z < 1e-3 && alpha_x < 1e-3;
 }
 
-double TrowbridgeReitzDistribution::G1(Vector3 w) const {
+Float TrowbridgeReitzDistribution::G1(Vector3 w) const {
   return 1.0 / (1.0 + Lambda(w));
 }
 
-double TrowbridgeReitzDistribution::Lambda(Vector3 w) const {
-  double tan2Theta = Tan2Theta(w);
+Float TrowbridgeReitzDistribution::Lambda(Vector3 w) const {
+  Float tan2Theta = Tan2Theta(w);
   if (std::isinf(tan2Theta))
     return 0;
-  double alpha2 = Sqr(CosPhi(w) * alpha_z) + Sqr(SinPhi(w) * alpha_x);
+  Float alpha2 = Sqr(CosPhi(w) * alpha_z) + Sqr(SinPhi(w) * alpha_x);
   return (std::sqrt(1 + alpha2 * tan2Theta) - 1) / 2;
 }
 
-double TrowbridgeReitzDistribution::G(Vector3 wi, Vector3 wo) const {
+Float TrowbridgeReitzDistribution::G(Vector3 wi, Vector3 wo) const {
   wi = -wi;
   return 1.0 / (1.0 + Lambda(wi) + Lambda(wo));
 }
 
-double TrowbridgeReitzDistribution::D(Vector3 w, Vector3 wm) const {
+Float TrowbridgeReitzDistribution::D(Vector3 w, Vector3 wm) const {
   return G1(w) / AbsCosTheta(w) * D(wm) * std::abs(w.Dot(wm));
 }
 
-double TrowbridgeReitzDistribution::PDF(Vector3 w, Vector3 wm) const {
+Float TrowbridgeReitzDistribution::PDF(Vector3 w, Vector3 wm) const {
   return D(w, wm);
 }
 
@@ -69,11 +69,11 @@ Vector3 TrowbridgeReitzDistribution::Sample_wm(Vector3 w) const {
 
   // Sample disk
   Point2 p = SampleUniformDiskPolar();
-  double h = std::sqrt(1 - Sqr(p.x()));
+  Float h = std::sqrt(1 - Sqr(p.x()));
   p.y() = std::lerp(h, p.y(), (1 + wh.y()) / 2);
 
   // Project back to hemisphere
-  double py = std::sqrt(std::max(0.0, 1 - Vector2(p).Length_squared()));
+  Float py = std::sqrt(std::max(0.0, 1 - Vector2(p).Length_squared()));
   Vector3 nh = p.x() * T1 + p.y() * T2 + py * wh;
 
   // Ellipsoid to hemisphere
@@ -81,13 +81,13 @@ Vector3 TrowbridgeReitzDistribution::Sample_wm(Vector3 w) const {
   return ans.Normalized();
 }
 
-double TrowbridgeReitzDistribution::RoughnessToAlpha(double roughness) {
+Float TrowbridgeReitzDistribution::RoughnessToAlpha(Float roughness) {
   return std::sqrt(roughness);
 }
 
 void TrowbridgeReitzDistribution::Regularize() {
   if (alpha_x < 0.3)
-    alpha_x = std::clamp<double>(2 * alpha_x, 0.1, 0.3);
+    alpha_x = std::clamp<Float>(2 * alpha_x, 0.1, 0.3);
   if (alpha_z < 0.3)
-    alpha_z = std::clamp<double>(2 * alpha_z, 0.1, 0.3);
+    alpha_z = std::clamp<Float>(2 * alpha_z, 0.1, 0.3);
 }

--- a/src/tracer/trowbridge_reitz_distribution.hpp
+++ b/src/tracer/trowbridge_reitz_distribution.hpp
@@ -6,30 +6,30 @@ class TrowbridgeReitzDistribution {
  public:
   // Constructors
   TrowbridgeReitzDistribution() = default;
-  TrowbridgeReitzDistribution(double ax, double az);
+  TrowbridgeReitzDistribution(Float ax, Float az);
 
   // NDF evaluation
-  double D(Vector3 wm) const;
+  Float D(Vector3 wm) const;
 
   // Visibility term
-  double G1(Vector3 w) const;
-  double G(Vector3 wi, Vector3 wo) const;
+  Float G1(Vector3 w) const;
+  Float G(Vector3 wi, Vector3 wo) const;
 
   // Masking-shadowing
-  double Lambda(Vector3 w) const;
+  Float Lambda(Vector3 w) const;
 
   // Combined D·G·abs(dot) / cos term
-  double D(Vector3 w, Vector3 wm) const;
-  double PDF(Vector3 w, Vector3 wm) const;
+  Float D(Vector3 w, Vector3 wm) const;
+  Float PDF(Vector3 w, Vector3 wm) const;
 
   // Sampling
   Vector3 Sample_wm(Vector3 w) const;
 
   // Helpers
-  static double RoughnessToAlpha(double roughness);
+  static Float RoughnessToAlpha(Float roughness);
   bool EffectivelySmooth() const;
   void Regularize();
 
  private:
-  double alpha_x = 0.0, alpha_z = 0.0;
+  Float alpha_x = 0.0, alpha_z = 0.0;
 };

--- a/src/tracer/util/aabb.cpp
+++ b/src/tracer/util/aabb.cpp
@@ -15,7 +15,7 @@
 
 AABB::AABB(std::initializer_list<Point3> li) {
   if (li.size() == 0) {
-    x_interval = y_interval = z_interval = Interval<double>::Empty;
+    x_interval = y_interval = z_interval = Interval<Float>::Empty;
     return;
   }
 
@@ -30,22 +30,22 @@ AABB::AABB(std::initializer_list<Point3> li) {
   auto max_z = std::ranges::max(li | std::views::transform(get_z_comp));
   auto min_z = std::ranges::min(li | std::views::transform(get_z_comp));
 
-  x_interval = Interval<double>(min_x, max_x);
-  y_interval = Interval<double>(min_y, max_y);
-  z_interval = Interval<double>(min_z, max_z);
+  x_interval = Interval<Float>(min_x, max_x);
+  y_interval = Interval<Float>(min_y, max_y);
+  z_interval = Interval<Float>(min_z, max_z);
 }
 
 AABB::AABB(std::initializer_list<AABB> li) {
   if (li.size() == 0) {
-    x_interval = y_interval = z_interval = Interval<double>::Empty;
+    x_interval = y_interval = z_interval = Interval<Float>::Empty;
     return;
   }
 
   auto get_axis = [](const AABB& box, const int axis) {
     return box.Axis(axis);
   };
-  auto get_min = [](const Interval<double>& it) { return it.begin; };
-  auto get_max = [](const Interval<double>& it) { return it.end; };
+  auto get_min = [](const Interval<Float>& it) { return it.begin; };
+  auto get_max = [](const Interval<Float>& it) { return it.end; };
 
   using namespace std::placeholders;
   auto get_x_axis = std::bind(get_axis, _1, 0);
@@ -64,9 +64,9 @@ AABB::AABB(std::initializer_list<AABB> li) {
   auto min_z = std::ranges::min(li | std::views::transform(get_z_axis) |
                                 std::views::transform(get_min));
 
-  x_interval = Interval<double>(min_x, max_x);
-  y_interval = Interval<double>(min_y, max_y);
-  z_interval = Interval<double>(min_z, max_z);
+  x_interval = Interval<Float>(min_x, max_x);
+  y_interval = Interval<Float>(min_y, max_y);
+  z_interval = Interval<Float>(min_z, max_z);
 }
 AABB::AABB(const Point3& a, const Point3& b) {
   x_interval = Interval(fmin(a.x(), b.x()), fmax(a.x(), b.x()));
@@ -78,7 +78,7 @@ AABB::AABB(const AABB& a, const AABB& b)
       y_interval(Interval(a.y_interval, b.y_interval)),
       z_interval(Interval(a.z_interval, b.z_interval)) {}
 
-const Interval<double>& AABB::Axis(const int& n) const {
+const Interval<Float>& AABB::Axis(const int& n) const {
   if (n == 0)
     return x_interval;
   if (n == 1)
@@ -91,7 +91,7 @@ const Interval<double>& AABB::Axis(const int& n) const {
                   n));
 }
 
-bool AABB::isHitIn(const Ray& r, Interval<double> ray_t) const {
+bool AABB::isHitIn(const Ray& r, Interval<Float> ray_t) const {
   for (int a = 0; a < 3; ++a) {
     auto invD = 1.0 / r.Direction()[a];
     auto orig = r.Origin()[a];
@@ -115,7 +115,7 @@ bool AABB::isHitIn(const Ray& r, Interval<double> ray_t) const {
   return true;
 }
 bool AABB::Contains(const Point3& p) const {
-  const double x = p.x(), y = p.y(), z = p.z();
+  const Float x = p.x(), y = p.y(), z = p.z();
   return x_interval.Contains(x) && y_interval.Contains(y) &&
          z_interval.Contains(z);
 }
@@ -131,12 +131,12 @@ bool AABB::isEmpty(void) const {
 }
 
 AABB AABB::Pad() const {
-  static double EPS = 1e-3;
-  Interval<double> xx =
+  static Float EPS = 1e-3;
+  Interval<Float> xx =
       (x_interval.Size() < EPS) ? x_interval.Expand(EPS) : x_interval;
-  Interval<double> yy =
+  Interval<Float> yy =
       (y_interval.Size() < EPS) ? y_interval.Expand(EPS) : y_interval;
-  Interval<double> zz =
+  Interval<Float> zz =
       (z_interval.Size() < EPS) ? z_interval.Expand(EPS) : z_interval;
   return AABB(xx, yy, zz);
 }

--- a/src/tracer/util/aabb.hpp
+++ b/src/tracer/util/aabb.hpp
@@ -14,10 +14,10 @@ class AABB {
   // All rays miss this cube thus miss the object
  public:
   explicit constexpr AABB()
-      : x_interval(Interval<double>::Empty),
-        y_interval(Interval<double>::Empty),
-        z_interval(Interval<double>::Empty) {}
-  constexpr AABB(Interval<double> x, Interval<double> y, Interval<double> z)
+      : x_interval(Interval<Float>::Empty),
+        y_interval(Interval<Float>::Empty),
+        z_interval(Interval<Float>::Empty) {}
+  constexpr AABB(Interval<Float> x, Interval<Float> y, Interval<Float> z)
       : x_interval(std::move(x)),
         y_interval(std::move(y)),
         z_interval(std::move(z)) {}
@@ -32,10 +32,10 @@ class AABB {
            z_interval == rhs.Axis(2);
   }
 
-  const Interval<double>& Axis(const int& n) const;
+  const Interval<Float>& Axis(const int& n) const;
 
   bool isEmpty() const;
-  bool isHitIn(const Ray&, Interval<double>) const;
+  bool isHitIn(const Ray&, Interval<Float>) const;
   bool Contains(const Point3&) const;
   bool Contains(const AABB&) const;
 
@@ -63,7 +63,7 @@ class AABB {
   }
 
  private:
-  Interval<double> x_interval, y_interval, z_interval;
+  Interval<Float> x_interval, y_interval, z_interval;
 };
 
 static_assert(Transformable<AABB>);

--- a/src/tracer/util/color.cpp
+++ b/src/tracer/util/color.cpp
@@ -5,11 +5,11 @@
 
 #include <cmath>
 
-inline static double Linear2Gamma(double linear_component) {
+inline static Float Linear2Gamma(Float linear_component) {
   return std::pow(linear_component, 1.0 / 2.2);
 }
 
-Color Format_Color(const Color& pixel_color, const double& scale) {
+Color Format_Color(const Color& pixel_color, const Float& scale) {
   auto r = pixel_color.x();
   auto g = pixel_color.y();
   auto b = pixel_color.z();

--- a/src/tracer/util/color.hpp
+++ b/src/tracer/util/color.hpp
@@ -2,7 +2,7 @@
 
 #include "util/vecmath.hpp"
 
-class Color : public basic_vector<double, 3> {
+class Color : public basic_vector<Float, 3> {
  private:
   using super = basic_vector;
 
@@ -11,7 +11,7 @@ class Color : public basic_vector<double, 3> {
   using value_type = typename super::value_type;
   static constexpr auto dimension = super::dimension;
 
-  explicit constexpr Color(double c) : super(c, c, c) {}
+  explicit constexpr Color(Float c) : super(c, c, c) {}
   explicit constexpr Color(vector_like auto c) : super(std::move(c)) {}
 
   inline constexpr value_type r() const { return v[0]; }
@@ -56,10 +56,10 @@ class Color : public basic_vector<double, 3> {
     return *this = *this / rhs;
   }
 
-  static constexpr Color Lerp(const Color& c1, const Color& c2, double t) {
+  static constexpr Color Lerp(const Color& c1, const Color& c2, Float t) {
     return Color(std::lerp(c1.x(), c2.x(), t), std::lerp(c1.y(), c2.y(), t),
                  std::lerp(c1.z(), c2.z(), t));
   }
 };
 
-Color Format_Color(const Color& pixel_color, const double& scale = 255.0);
+Color Format_Color(const Color& pixel_color, const Float& scale = 255.0);

--- a/src/tracer/util/constant.hpp
+++ b/src/tracer/util/constant.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#include "util/prshdefs.hpp"
+
 #include <limits>
 #include <numbers>
 
 // Constants
-constexpr double infinity = std::numeric_limits<double>::infinity();
-using std::numbers::pi;
-constexpr double invpi = 1.0 / pi;
+constexpr Float infinity = std::numeric_limits<Float>::infinity();
+inline constexpr Float pi = std::numbers::pi_v<Float>;
+constexpr Float invpi = static_cast<Float>(1.0) / pi;

--- a/src/tracer/util/interval.cpp
+++ b/src/tracer/util/interval.cpp
@@ -1,10 +1,10 @@
 #include "interval.hpp"
 
 template <>
-Interval<double> Interval<double>::Positive() {
-  return Interval<double>(1e-8, 1e8);
+Interval<Float> Interval<Float>::Positive() {
+  return Interval<Float>(1e-8, 1e8);
 }
 template <>
-Interval<double> Interval<double>::Universe() {
-  return Interval<double>(-1e8, 1e8);
+Interval<Float> Interval<Float>::Universe() {
+  return Interval<Float>(-1e8, 1e8);
 }

--- a/src/tracer/util/interval.hpp
+++ b/src/tracer/util/interval.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
+#include "util/prshdefs.hpp"
+
 #include <iostream>
 
 template <typename T>
 class Interval {
  private:
-  static constexpr double EPS = 1e-8;
+  static constexpr Float EPS = 1e-8;
 
  public:
   T begin, end;
@@ -23,7 +25,7 @@ class Interval {
            (end - EPS < rhs.end && rhs.end < end + EPS);
   }
 
-  constexpr Interval Expand(double x) const {
+  constexpr Interval Expand(Float x) const {
     return Interval(begin - x, end + x);
   }
 

--- a/src/tracer/util/matrix.hpp
+++ b/src/tracer/util/matrix.hpp
@@ -11,7 +11,7 @@
 #include <stdexcept>
 #include <utility>
 
-template <std::size_t R, std::size_t C, typename value_type = double>
+template <std::size_t R, std::size_t C, typename value_type = Float>
 class Matrix {
   static_assert(R > 0 && C > 0, "Matrix must have non‑zero dimensions");
 
@@ -304,5 +304,5 @@ class Matrix {
   }
 };
 
-/* convenient alias for 4×4 double matrix (graphics etc.) */
-using Matrix4 = Matrix<4, 4, double>;
+/* convenient alias for 4×4 Float matrix (graphics etc.) */
+using Matrix4 = Matrix<4, 4, Float>;

--- a/src/tracer/util/prshdefs.hpp
+++ b/src/tracer/util/prshdefs.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+using Float = double;
+

--- a/src/tracer/util/random.cpp
+++ b/src/tracer/util/random.cpp
@@ -7,13 +7,13 @@ static std::mt19937 gen([] {
   return rd();
 }());
 
-double random_uniform_01() {
-  static std::uniform_real_distribution<double> distribution(0.0, 1.0);
+Float random_uniform_01() {
+  static std::uniform_real_distribution<Float> distribution(0.0, 1.0);
   return distribution(gen);
 }
 
-double random_double(double min, double max) {
-  std::uniform_real_distribution<double> distribution(min, max);
+Float random_double(Float min, Float max) {
+  std::uniform_real_distribution<Float> distribution(min, max);
   return distribution(gen);
 }
 

--- a/src/tracer/util/random.hpp
+++ b/src/tracer/util/random.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-double random_uniform_01();
+#include "util/prshdefs.hpp"
 
-double random_double(double min, double max);
+Float random_uniform_01();
+
+Float random_double(Float min, Float max);
 
 int random_int(int min, int max);

--- a/src/tracer/util/ray.cpp
+++ b/src/tracer/util/ray.cpp
@@ -4,7 +4,7 @@
 
 #include <cmath>
 
-Point3 Ray::At(const double& time) const { return origin + time * direction; }
+Point3 Ray::At(const Float& time) const { return origin + time * direction; }
 
 Ray Ray::Transform(const ITransformation& tr) const {
   return Ray(tr.Doit(Origin()), tr.Doit(Direction()));

--- a/src/tracer/util/ray.hpp
+++ b/src/tracer/util/ray.hpp
@@ -22,7 +22,7 @@ struct Ray {
     return *this;
   }
 
-  Point3 At(const double&) const;
+  Point3 At(const Float&) const;
 
   Ray Transform(const ITransformation&) const;
   Ray UndoTransform(const ITransformation&) const;

--- a/src/tracer/util/sampling.cpp
+++ b/src/tracer/util/sampling.cpp
@@ -3,23 +3,23 @@
 #include <util/random.hpp>
 #include <util/vector.hpp>
 
-double pdf_cosine_distributed_hemisphere(const Vector3& wo) {
-  const double len_sq = wo.Length_squared();
+Float pdf_cosine_distributed_hemisphere(const Vector3& wo) {
+  const Float len_sq = wo.Length_squared();
   if (len_sq == 0)
     return invpi;  // treat as aligned with +Z
   if (wo.y() <= 0)
     return 0;
-  double costheta = wo.y() / std::sqrt(len_sq);
+  Float costheta = wo.y() / std::sqrt(len_sq);
   return costheta * invpi;
 }
 
 Vector3 Spawn_cosine_distributed_hemisphere() {
-  double r1 = random_uniform_01(), r2 = random_uniform_01();
-  double phi = r1 * 2 * pi;
+  Float r1 = random_uniform_01(), r2 = random_uniform_01();
+  Float phi = r1 * 2 * pi;
 
-  double dx = cos(phi) * std::sqrt(r2);
-  double dz = sin(phi) * std::sqrt(r2);
-  double dy = std::sqrt(1 - r2);
+  Float dx = cos(phi) * std::sqrt(r2);
+  Float dz = sin(phi) * std::sqrt(r2);
+  Float dy = std::sqrt(1 - r2);
 
   return Vector3{dx, dy, dz};
 }

--- a/src/tracer/util/sampling.hpp
+++ b/src/tracer/util/sampling.hpp
@@ -4,40 +4,40 @@
 #include "util/random.hpp"
 #include "util/vector.hpp"
 
-double pdf_cosine_distributed_hemisphere(const Vector3& wo);
+Float pdf_cosine_distributed_hemisphere(const Vector3& wo);
 
 Vector3 Spawn_cosine_distributed_hemisphere();
 
 inline static Vector3 rand_hemisphere_uniform() {
-  double u1 = random_uniform_01();
-  double u2 = random_uniform_01();
-  double phi = 2.0 * pi * u1;
-  double cos_theta = u2;
-  double sin_theta = std::sqrt(1.0 - cos_theta * cos_theta);
-  double x = sin_theta * std::cos(phi);
-  double y = cos_theta;
-  double z = sin_theta * std::sin(phi);
+  Float u1 = random_uniform_01();
+  Float u2 = random_uniform_01();
+  Float phi = 2.0 * pi * u1;
+  Float cos_theta = u2;
+  Float sin_theta = std::sqrt(1.0 - cos_theta * cos_theta);
+  Float x = sin_theta * std::cos(phi);
+  Float y = cos_theta;
+  Float z = sin_theta * std::sin(phi);
   return Vector3{x, y, z};
 }
 
 inline static Vector3 rand_sphere_uniform() {
   // u1 → controls z coordinate in [-1,1]
   // u2 → controls azimuth around the z-axis
-  double u1 = random_uniform_01();
-  double u2 = random_uniform_01();
-  double z = 1.0 - 2.0 * u1;                         // Uniform in [-1,1]
-  double r = std::sqrt(std::max(0.0, 1.0 - z * z));  // Radius in xy-plane
-  double phi = 2.0 * pi * u2;                        // Uniform in [0,2pi)
+  Float u1 = random_uniform_01();
+  Float u2 = random_uniform_01();
+  Float z = 1.0 - 2.0 * u1;                         // Uniform in [-1,1]
+  Float r = std::sqrt(std::max(0.0, 1.0 - z * z));  // Radius in xy-plane
+  Float phi = 2.0 * pi * u2;                        // Uniform in [0,2pi)
 
-  double x = r * std::cos(phi);
-  double y = r * std::sin(phi);
+  Float x = r * std::cos(phi);
+  Float y = r * std::sin(phi);
 
   return Vector3{x, y, z};
 }
 
 inline Point2 SampleUniformDiskPolar() {
-  double u0 = random_uniform_01(), u1 = random_uniform_01();
-  double r = std::sqrt(u0);
-  double theta = 2 * pi * u1;
+  Float u0 = random_uniform_01(), u1 = random_uniform_01();
+  Float r = std::sqrt(u0);
+  Float theta = 2 * pi * u1;
   return Point2{r * std::cos(theta), r * std::sin(theta)};
 }

--- a/src/tracer/util/transform.cpp
+++ b/src/tracer/util/transform.cpp
@@ -65,7 +65,7 @@ Normal VectorScale::Undo(Normal n) const {
 
 // --------------------------------------------------------------------------------
 Point3 MatrixTransformation::Doit(Point3 p) const {
-  basic_vector<double, 4> w(p.x(), p.y(), p.z(), 1);
+  basic_vector<Float, 4> w(p.x(), p.y(), p.z(), 1);
   w = m * w;
   static constexpr auto EPS = 1e-9;
   auto ans = Vector3(w.x(), w.y(), w.z());
@@ -75,7 +75,7 @@ Point3 MatrixTransformation::Doit(Point3 p) const {
 }
 
 Vector3 MatrixTransformation::Doit(Vector3 p) const {
-  basic_vector<double, 4> w(p.x(), p.y(), p.z(), 0);
+  basic_vector<Float, 4> w(p.x(), p.y(), p.z(), 0);
   w = m * w;
   return Vector3(w.x(), w.y(), w.z());
 }
@@ -95,7 +95,7 @@ Vector3 MatrixTransformation::Doit(Vector3 p) const {
  * @return A new Normal object: the transformed normal.
  */
 Normal MatrixTransformation::Doit(Normal p) const {
-  basic_vector<double, 4> w(p.x(), p.y(), p.z(), 0);
+  basic_vector<Float, 4> w(p.x(), p.y(), p.z(), 0);
   w = minv.T() * w;
   return Normal(w.x(), w.y(), w.z());
 }
@@ -111,20 +111,20 @@ MatrixTransformation MatrixTransformation::Translate(Vector3 p) {
       Matrix4{1, 0, 0, p.x(), 0, 1, 0, p.y(), 0, 0, 1, p.z(), 0, 0, 0, 1},
       Matrix4{1, 0, 0, -p.x(), 0, 1, 0, -p.y(), 0, 0, 1, -p.z(), 0, 0, 0, 1});
 }
-MatrixTransformation MatrixTransformation::Translate(double dx,
-                                                     double dy,
-                                                     double dz) {
+MatrixTransformation MatrixTransformation::Translate(Float dx,
+                                                     Float dy,
+                                                     Float dz) {
   return Translate(Vector3{dx, dy, dz});
 }
 
-MatrixTransformation MatrixTransformation::Rotate(basic_vector<double, 3> axis,
-                                                  double costheta,
-                                                  double sintheta) {
+MatrixTransformation MatrixTransformation::Rotate(basic_vector<Float, 3> axis,
+                                                  Float costheta,
+                                                  Float sintheta) {
   axis = axis.normalised();
 
-  auto R = [](const basic_vector<double, 3>& axis, double costheta,
-              double sintheta) {
-    const double nx = axis.x(), ny = axis.y(), nz = axis.z();
+  auto R = [](const basic_vector<Float, 3>& axis, Float costheta,
+              Float sintheta) {
+    const Float nx = axis.x(), ny = axis.y(), nz = axis.z();
     return Matrix4{nx * nx * (1 - costheta) + costheta,
                    nx * ny * (1 - costheta) + nz * sintheta,
                    nx * nz * (1 - costheta) - ny * sintheta,
@@ -149,31 +149,31 @@ MatrixTransformation MatrixTransformation::Rotate(basic_vector<double, 3> axis,
   return MatrixTransformation(RotateMat, RotateMatInv);
 }
 MatrixTransformation MatrixTransformation::Rotate(
-    const basic_vector<double, 3>& axis,
-    double theta) {
-  double costheta = cos(theta);
-  double sintheta = sin(theta);
+    const basic_vector<Float, 3>& axis,
+    Float theta) {
+  Float costheta = cos(theta);
+  Float sintheta = sin(theta);
   return Rotate(axis, costheta, sintheta);
 }
-MatrixTransformation MatrixTransformation::RotateX(double theta) {
+MatrixTransformation MatrixTransformation::RotateX(Float theta) {
   return Rotate(Vector3{1, 0, 0}, theta);
 }
-MatrixTransformation MatrixTransformation::RotateX(double costheta,
-                                                   double sintheta) {
+MatrixTransformation MatrixTransformation::RotateX(Float costheta,
+                                                   Float sintheta) {
   return Rotate(Vector3{1, 0, 0}, costheta, sintheta);
 }
-MatrixTransformation MatrixTransformation::RotateY(double theta) {
+MatrixTransformation MatrixTransformation::RotateY(Float theta) {
   return Rotate(Vector3{0, 1, 0}, theta);
 }
-MatrixTransformation MatrixTransformation::RotateY(double costheta,
-                                                   double sintheta) {
+MatrixTransformation MatrixTransformation::RotateY(Float costheta,
+                                                   Float sintheta) {
   return Rotate(Vector3{0, 1, 0}, costheta, sintheta);
 }
-MatrixTransformation MatrixTransformation::RotateZ(double theta) {
+MatrixTransformation MatrixTransformation::RotateZ(Float theta) {
   return Rotate(Vector3{0, 0, 1}, theta);
 }
-MatrixTransformation MatrixTransformation::RotateZ(double costheta,
-                                                   double sintheta) {
+MatrixTransformation MatrixTransformation::RotateZ(Float costheta,
+                                                   Float sintheta) {
   return Rotate(Vector3{0, 0, 1}, costheta, sintheta);
 }
 
@@ -234,11 +234,11 @@ MatrixTransformation MatrixTransformation::AlignXYZ(
   return MatrixTransformation::AlignXYZ(basis.x(), basis.y(), basis.z());
 }
 
-MatrixTransformation MatrixTransformation::Scale(double x, double y, double z) {
+MatrixTransformation MatrixTransformation::Scale(Float x, Float y, Float z) {
   return MatrixTransformation::Scale(Vector3{x, y, z});
 }
 MatrixTransformation MatrixTransformation::Scale(Vector3 n) {
-  auto ScaleMat = [](double kx, double ky, double kz) {
+  auto ScaleMat = [](Float kx, Float ky, Float kz) {
     return Matrix4{kx, 0, 0, 0, 0, ky, 0, 0, 0, 0, kz, 0, 0, 0, 0, 1};
   };
 
@@ -247,9 +247,9 @@ MatrixTransformation MatrixTransformation::Scale(Vector3 n) {
 
   return MatrixTransformation(mat, matinv);
 }
-MatrixTransformation MatrixTransformation::Scale(Vector3 n, double k) {
-  auto ScaleMat = [](const Vector3& n, double k) {
-    const double nx = n.x(), ny = n.y(), nz = n.z();
+MatrixTransformation MatrixTransformation::Scale(Vector3 n, Float k) {
+  auto ScaleMat = [](const Vector3& n, Float k) {
+    const Float nx = n.x(), ny = n.y(), nz = n.z();
     --k;
     return Matrix4{1 + k * nx * nx,
                    k * nx * ny,
@@ -318,37 +318,37 @@ Quaternion Quaternion::operator*(const Quaternion& rhs) const {
                     v.Cross(rhs.v) + s * rhs.v + rhs.s * v);
 }
 
-Quaternion Quaternion::operator*(double r) const {
+Quaternion Quaternion::operator*(Float r) const {
   return Quaternion(r * s, r * v);
 }
 
-Quaternion Quaternion::operator/(double r) const {
+Quaternion Quaternion::operator/(Float r) const {
   return Quaternion(s / r, v / r);
 }
 
 Quaternion Quaternion::conj(void) const { return Quaternion(s, -v); }
 
-double Quaternion::sqrnorm(void) const { return this->Dot(*this); }
-double Quaternion::norm(void) const { return sqrt(this->Dot(*this)); }
+Float Quaternion::sqrnorm(void) const { return this->Dot(*this); }
+Float Quaternion::norm(void) const { return sqrt(this->Dot(*this)); }
 
-double Quaternion::Dot(const Quaternion& rhs) const {
+Float Quaternion::Dot(const Quaternion& rhs) const {
   return s * rhs.s + v.Dot(rhs.v);
 }
 
 Quaternion Quaternion::inv(void) const { return conj() / sqrnorm(); }
 
 // --------------------------------------------------------------------------------
-basic_vector<double, 3> QuaternionTransform::Doit_impl(
-    const basic_vector<double, 3>& it) const {
+basic_vector<Float, 3> QuaternionTransform::Doit_impl(
+    const basic_vector<Float, 3>& it) const {
   auto p = Quaternion(0, it.x(), it.y(), it.z());
   p = q * p * qinv;
-  return (basic_vector<double, 3>)p.v;
+  return (basic_vector<Float, 3>)p.v;
 }
-basic_vector<double, 3> QuaternionTransform::Undo_impl(
-    const basic_vector<double, 3>& it) const {
+basic_vector<Float, 3> QuaternionTransform::Undo_impl(
+    const basic_vector<Float, 3>& it) const {
   auto p = Quaternion(0, it.x(), it.y(), it.z());
   p = qinv * p * q;
-  return (basic_vector<double, 3>)p.v;
+  return (basic_vector<Float, 3>)p.v;
 }
 Point3 QuaternionTransform::Doit(Point3 pt) const {
   return (Point3)Doit_impl(pt);
@@ -371,8 +371,8 @@ Normal QuaternionTransform::Undo(Normal n) const {
 
 // requires normalized n
 QuaternionTransform QuaternionTransform::Rotate(
-    const basic_vector<double, 3>& n,
-    double theta) {
+    const basic_vector<Float, 3>& n,
+    Float theta) {
   assert(n.normalised() == n);
   theta *= -0.5;
   auto q = Quaternion(cos(theta), sin(theta) * n);
@@ -398,7 +398,7 @@ QuaternionTransform QuaternionTransform::RotateFrTo(Vector3 fr, Vector3 to) {
     return Rotate(axis.Normalized(), M_PI);
   }
 
-  double theta = acos(fr.Dot(to));
+  Float theta = acos(fr.Dot(to));
   auto axis = fr.Cross(to).Normalized();
   return QuaternionTransform::Rotate(axis, -theta);
 }
@@ -414,11 +414,11 @@ QuaternionTransform QuaternionTransform::RotateFrTo(Vector3 fr, Vector3 to) {
 QuaternionTransform QuaternionTransform::AlignXYZ(Vector3 i,
                                                   Vector3 j,
                                                   Vector3 k) {
-  double w = sqrt(1 + i.x() + j.y() + k.z()) / 2;
-  double wquarter = 1.0 / (4 * w);
-  double x = (j.z() - k.y()) * wquarter;
-  double y = (k.x() - i.z()) * wquarter;
-  double z = (i.y() - j.x()) * wquarter;
+  Float w = sqrt(1 + i.x() + j.y() + k.z()) / 2;
+  Float wquarter = 1.0 / (4 * w);
+  Float x = (j.z() - k.y()) * wquarter;
+  Float y = (k.x() - i.z()) * wquarter;
+  Float z = (i.y() - j.x()) * wquarter;
 
   auto q = Quaternion(w, x, y, z);
   q /= q.norm();

--- a/src/tracer/util/transform.hpp
+++ b/src/tracer/util/transform.hpp
@@ -58,11 +58,11 @@ extern std::shared_ptr<ITransformation> const identity_transform;
  */
 class VectorTranslate : public ITransformation {
  private:
-  double dx, dy, dz;
+  Float dx, dy, dz;
 
  public:
   constexpr VectorTranslate() noexcept : dx(0.0), dy(0.0), dz(0.0) {}
-  constexpr VectorTranslate(double ix, double iy, double iz) noexcept
+  constexpr VectorTranslate(Float ix, Float iy, Float iz) noexcept
       : dx(ix), dy(iy), dz(iz) {}
   VectorTranslate(Vector3 v);
 
@@ -74,7 +74,7 @@ class VectorTranslate : public ITransformation {
   Normal Undo(Normal) const override;
 
  public:
-  static VectorTranslate Translate(double x, double y, double z) {
+  static VectorTranslate Translate(Float x, Float y, Float z) {
     return VectorTranslate(x, y, z);
   }
   inline static VectorTranslate Translate(Vector3 v) {
@@ -90,11 +90,11 @@ class VectorTranslate : public ITransformation {
  */
 class VectorScale : public ITransformation {
  private:
-  double dx, dy, dz;
+  Float dx, dy, dz;
 
  public:
   constexpr VectorScale() noexcept : dx(1.0), dy(1.0), dz(1.0) {}
-  constexpr VectorScale(double ix, double iy, double iz) noexcept
+  constexpr VectorScale(Float ix, Float iy, Float iz) noexcept
       : dx(ix), dy(iy), dz(iz) {}
   VectorScale(Vector3 v);
 
@@ -106,7 +106,7 @@ class VectorScale : public ITransformation {
   Normal Undo(Normal) const override;
 
  public:
-  static VectorScale Scale(double x, double y, double z) {
+  static VectorScale Scale(Float x, Float y, Float z) {
     return VectorScale(x, y, z);
   }
   inline static VectorScale Scale(Vector3 v) {
@@ -187,19 +187,19 @@ class MatrixTransformation : public ITransformation {
   // factory methods for creating the transformation matrix
  public:
   static MatrixTransformation Translate(Vector3 p);
-  static MatrixTransformation Translate(double dx, double dy, double dz);
+  static MatrixTransformation Translate(Float dx, Float dy, Float dz);
 
-  static MatrixTransformation Rotate(basic_vector<double, 3> axis,
-                                     double costheta,
-                                     double sintheta);
-  static MatrixTransformation Rotate(const basic_vector<double, 3>& axis,
-                                     double theta);
-  static MatrixTransformation RotateX(double theta);
-  static MatrixTransformation RotateX(double costheta, double sintheta);
-  static MatrixTransformation RotateY(double theta);
-  static MatrixTransformation RotateY(double costheta, double sintheta);
-  static MatrixTransformation RotateZ(double theta);
-  static MatrixTransformation RotateZ(double costheta, double sintheta);
+  static MatrixTransformation Rotate(basic_vector<Float, 3> axis,
+                                     Float costheta,
+                                     Float sintheta);
+  static MatrixTransformation Rotate(const basic_vector<Float, 3>& axis,
+                                     Float theta);
+  static MatrixTransformation RotateX(Float theta);
+  static MatrixTransformation RotateX(Float costheta, Float sintheta);
+  static MatrixTransformation RotateY(Float theta);
+  static MatrixTransformation RotateY(Float costheta, Float sintheta);
+  static MatrixTransformation RotateZ(Float theta);
+  static MatrixTransformation RotateZ(Float costheta, Float sintheta);
   static MatrixTransformation RotateFrTo(Vector3 fr, Vector3 to);
   /**
    * @brief Creates a transformation matrix that aligns the global coordinate
@@ -212,9 +212,9 @@ class MatrixTransformation : public ITransformation {
   static MatrixTransformation AlignXYZ(const basic_vector<Vector3, 3>&);
   static MatrixTransformation AlignXYZ(Vector3, Vector3, Vector3);
 
-  static MatrixTransformation Scale(double, double, double);
+  static MatrixTransformation Scale(Float, Float, Float);
   static MatrixTransformation Scale(Vector3 n);
-  static MatrixTransformation Scale(Vector3 n, double k);
+  static MatrixTransformation Scale(Vector3 n, Float k);
 
   /// Returns a transformation T such that
   ///   T.Doit(a) == Point3(0,0,0),
@@ -231,9 +231,9 @@ class MatrixTransformation : public ITransformation {
 
 class Quaternion {
  public:
-  constexpr Quaternion(double is, double ix, double iy, double iz) noexcept
+  constexpr Quaternion(Float is, Float ix, Float iy, Float iz) noexcept
       : s(is), v(ix, iy, iz) {}
-  Quaternion(double is, basic_vector<double, 3> iv) : s(is), v(std::move(iv)) {}
+  Quaternion(Float is, basic_vector<Float, 3> iv) : s(is), v(std::move(iv)) {}
 
   Quaternion operator+(const Quaternion& rhs) const;
   Quaternion& operator+=(const Quaternion& rhs) { return *this = *this + rhs; }
@@ -242,25 +242,25 @@ class Quaternion {
 
   Quaternion operator*(const Quaternion& rhs) const;
   Quaternion& operator*=(const Quaternion& rhs) { return *this = *this * rhs; }
-  Quaternion operator*(double r) const;
-  Quaternion& operator*=(double r) { return *this = *this * r; }
-  friend Quaternion operator*(double r, const Quaternion& rhs) {
+  Quaternion operator*(Float r) const;
+  Quaternion& operator*=(Float r) { return *this = *this * r; }
+  friend Quaternion operator*(Float r, const Quaternion& rhs) {
     return rhs * r;
   }
-  Quaternion operator/(double r) const;
-  Quaternion& operator/=(double r) { return *this = *this / r; }
+  Quaternion operator/(Float r) const;
+  Quaternion& operator/=(Float r) { return *this = *this / r; }
 
   Quaternion conj(void) const;
 
-  double sqrnorm(void) const;
-  double norm(void) const;
+  Float sqrnorm(void) const;
+  Float norm(void) const;
 
-  double Dot(const Quaternion&) const;
+  Float Dot(const Quaternion&) const;
 
   Quaternion inv(void) const;
 
  public:
-  double s;
+  Float s;
   Vector3 v;
 };
 
@@ -280,8 +280,8 @@ class QuaternionTransform : public ITransformation {
  private:
   Quaternion q, qinv;
 
-  basic_vector<double, 3> Doit_impl(const basic_vector<double, 3>&) const;
-  basic_vector<double, 3> Undo_impl(const basic_vector<double, 3>&) const;
+  basic_vector<Float, 3> Doit_impl(const basic_vector<Float, 3>&) const;
+  basic_vector<Float, 3> Undo_impl(const basic_vector<Float, 3>&) const;
 
  public:
   /**
@@ -298,7 +298,7 @@ class QuaternionTransform : public ITransformation {
    * auto qt = QuaternionTransform::Rotate(Vector3(0, 0, 1), M_PI / 4);
    * // Rotate 45 degrees around the Z-axis
    */
-  static QuaternionTransform Rotate(const basic_vector<double, 3>&, double);
+  static QuaternionTransform Rotate(const basic_vector<Float, 3>&, Float);
   static QuaternionTransform RotateFrTo(Vector3 fr, Vector3 to);
 
   /**

--- a/src/tracer/util/util.hpp
+++ b/src/tracer/util/util.hpp
@@ -52,20 +52,20 @@ inline Vector3 Reflect(const Vector3& wi, const Vector3& n) {
 
 inline bool Refract(Vector3 v,
                     const Vector3& n,
-                    double eta_ratio,
+                    Float eta_ratio,
                     Vector3* out) {
   if (!out)
     return false;
 
   v = -v;
-  const double cosThetaI = v.Dot(n);
-  const double sin2ThetaI = std::max(0.0, 1.0 - cosThetaI * cosThetaI);
-  const double sin2ThetaT = eta_ratio * eta_ratio * sin2ThetaI;
+  const Float cosThetaI = v.Dot(n);
+  const Float sin2ThetaI = std::max(0.0, 1.0 - cosThetaI * cosThetaI);
+  const Float sin2ThetaT = eta_ratio * eta_ratio * sin2ThetaI;
 
   if (sin2ThetaT >= 1.0)
     return false;
 
-  const double cosThetaT = std::sqrt(std::max(0.0, 1.0 - sin2ThetaT));
+  const Float cosThetaT = std::sqrt(std::max(0.0, 1.0 - sin2ThetaT));
 
   *out = eta_ratio * (-v) + (eta_ratio * cosThetaI - cosThetaT) * n;
   out->y() *= out->y() * v.y() < 0 ? 1 : -1;

--- a/src/tracer/util/vecmath.hpp
+++ b/src/tracer/util/vecmath.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "util/prshdefs.hpp"
 #include <algorithm>
 #include <array>
 #include <cassert>

--- a/src/tracer/util/vector.cpp
+++ b/src/tracer/util/vector.cpp
@@ -7,7 +7,7 @@
 
 template <>
 Vector<3> Vector<3>::Random_Unit(void) {
-  double x, y, z, pi = std::numbers::pi;
+  Float x, y, z, pi = std::numbers::pi;
   auto r1 = random_uniform_01(), r2 = random_uniform_01();
   x = cos(2 * pi * r1) * 2 * std::sqrt(r2 * (1 - r2));
   y = sin(2 * pi * r1) * 2 * std::sqrt(r2 * (1 - r2));
@@ -15,7 +15,7 @@ Vector<3> Vector<3>::Random_Unit(void) {
   return Vector<3>{x, y, z};
 }
 template <>
-Vector<3> Vector<3>::Random(const double& min, const double& max) {
+Vector<3> Vector<3>::Random(const Float& min, const Float& max) {
   return Vector<3>{random_double(min, max), random_double(min, max),
                    random_double(min, max)};
 }

--- a/src/tracer/util/vector.hpp
+++ b/src/tracer/util/vector.hpp
@@ -16,9 +16,9 @@
 class ITransformation;
 
 template <std::size_t N>
-class Vector : public basic_vector<double, N> {
+class Vector : public basic_vector<Float, N> {
  private:
-  using super = basic_vector<double, N>;
+  using super = basic_vector<Float, N>;
   static constexpr auto EPS = super::EPS;
 
  public:
@@ -93,15 +93,15 @@ class Vector : public basic_vector<double, N> {
   }
 
   static Vector<N> Random_Unit(void);
-  static Vector<N> Random(const double& min, const double& max);
+  static Vector<N> Random(const Float& min, const Float& max);
 
   Vector<N> Transform(const ITransformation&) const;
 };
 
 template <std::size_t N>
-class Point : public basic_vector<double, N> {
+class Point : public basic_vector<Float, N> {
  private:
-  using super = basic_vector<double, N>;
+  using super = basic_vector<Float, N>;
 
  public:
   using super::super;
@@ -133,7 +133,7 @@ class Point : public basic_vector<double, N> {
   }
 };
 
-class Normal : public basic_vector<double, 3> {
+class Normal : public basic_vector<Float, 3> {
  private:
   using super = basic_vector;
 
@@ -178,7 +178,7 @@ template <vector_like U, vector_like V>
 bool IsParallel(U const& a, V const& b) {
   for (std::size_t i = 0; i < a.dimension; ++i)
     if (b[i] != 0) {
-      double t = a[i] / b[i];
+      Float t = a[i] / b[i];
       return b * t == a;
     }
   return true;
@@ -188,23 +188,23 @@ template <vector_like U, vector_like V>
 inline bool IsPerpendicular(U const& a, V const& b) {
   return std::abs(a.Dot(b)) < U::EPS;
 }
-inline double CosTheta(const Vector3& w) { return w.y(); }
-inline double AbsCosTheta(const Vector3& w) { return std::abs(w.y()); }
-inline double Cos2Theta(const Vector3& w) { return w.y() * w.y(); }
-inline double Sin2Theta(const Vector3& w) {
-  return std::max<double>(0, 1 - Cos2Theta(w));
+inline Float CosTheta(const Vector3& w) { return w.y(); }
+inline Float AbsCosTheta(const Vector3& w) { return std::abs(w.y()); }
+inline Float Cos2Theta(const Vector3& w) { return w.y() * w.y(); }
+inline Float Sin2Theta(const Vector3& w) {
+  return std::max<Float>(0, 1 - Cos2Theta(w));
 }
-inline double SinTheta(const Vector3& w) { return std::sqrt(Sin2Theta(w)); }
-inline double Tan2Theta(const Vector3& w) {
+inline Float SinTheta(const Vector3& w) { return std::sqrt(Sin2Theta(w)); }
+inline Float Tan2Theta(const Vector3& w) {
   return Sin2Theta(w) / Cos2Theta(w);
 }
-inline double CosPhi(const Vector3& w) {
-  double sintheta = SinTheta(w);
-  return sintheta == 0 ? 1.0 : std::clamp<double>(w.z() / sintheta, -1, 1);
+inline Float CosPhi(const Vector3& w) {
+  Float sintheta = SinTheta(w);
+  return sintheta == 0 ? 1.0 : std::clamp<Float>(w.z() / sintheta, -1, 1);
 }
-inline double SinPhi(const Vector3& w) {
-  double sintheta = SinTheta(w);
-  return sintheta == 0 ? 0.0 : std::clamp<double>(w.x() / sintheta, -1, 1);
+inline Float SinPhi(const Vector3& w) {
+  Float sintheta = SinTheta(w);
+  return sintheta == 0 ? 0.0 : std::clamp<Float>(w.x() / sintheta, -1, 1);
 }
 
 inline static bool SameHemisphere(const Vector3& w, const Vector3& wp) {

--- a/test/aabb-test.cpp
+++ b/test/aabb-test.cpp
@@ -14,15 +14,15 @@
 class aabbTest : public ::testing::Test {
  protected:
   void SetUp() {
-    Interval<double> np1(-1, 1);
+    Interval<Float> np1(-1, 1);
     unit = AABB(np1, np1, np1);
 
-    universe = AABB(Interval<double>::Universe(), Interval<double>::Universe(),
-                    Interval<double>::Universe());
+    universe = AABB(Interval<Float>::Universe(), Interval<Float>::Universe(),
+                    Interval<Float>::Universe());
 
     b1 = AABB(Point3(-0.5, -1, -1), Point3(0.5, 1, 1));
-    b2 = AABB(Interval<double>::Universe(), Interval<double>::Empty,
-              Interval<double>::Universe());
+    b2 = AABB(Interval<Float>::Universe(), Interval<Float>::Empty,
+              Interval<Float>::Universe());
   }
 
   AABB empty, universe;
@@ -31,7 +31,7 @@ class aabbTest : public ::testing::Test {
 
   testing::AssertionResult CheckIntersect(const AABB& box,
                                           const Ray& r,
-                                          const Interval<double>& interval) {
+                                          const Interval<Float>& interval) {
     if (box.isHitIn(r, interval))
       return testing::AssertionSuccess()
              << "Ray r=" << r << " hits bbox b=" << box << " in time interval "
@@ -47,13 +47,13 @@ TEST_F(aabbTest, rayIntersectHit) {
   Ray r;
   for (const auto& box : {unit, universe}) {
     r = Ray(Point3(0, -3, 0), Point3(1, 0, 0) - Point3(0, -3, 0));
-    EXPECT_TRUE(CheckIntersect(box, r, Interval<double>::Positive()));
+    EXPECT_TRUE(CheckIntersect(box, r, Interval<Float>::Positive()));
 
     r = Ray(Point3(0, -2, 0), Point3(1.999, 0, 0) - Point3(0, -2, 0));
-    EXPECT_TRUE(CheckIntersect(box, r, Interval<double>::Positive()));
+    EXPECT_TRUE(CheckIntersect(box, r, Interval<Float>::Positive()));
 
     r = Ray(Point3(3, -4, 8), Vector3(-3, 4, -8));
-    EXPECT_TRUE(CheckIntersect(box, r, Interval<double>::Positive()));
+    EXPECT_TRUE(CheckIntersect(box, r, Interval<Float>::Positive()));
   }
 }
 
@@ -61,7 +61,7 @@ TEST_F(aabbTest, rayIntersectNoHit) {
   Ray r;
   for (const auto& box : {b1, b2}) {
     r = Ray(Point3(0, -2, 0), Point3(2, 0, 0) - Point3(0, -2, 0));
-    EXPECT_FALSE(box.isHitIn(r, Interval<double>::Positive()))
+    EXPECT_FALSE(box.isHitIn(r, Interval<Float>::Positive()))
         << r.Origin() << ' ' << r.Direction();
 
     r = Ray(Point3(2, 2, 2), Vector3(1, 1, 1));
@@ -78,14 +78,14 @@ TEST_F(aabbTest, parallelRayHit) {
   const AABB& box = unit;
 
   Ray r(Point3(-3, 0, 0), Vector3(-1, 0, 0));
-  EXPECT_TRUE(box.isHitIn(r, Interval<double>{-1e10, 1e10}))
+  EXPECT_TRUE(box.isHitIn(r, Interval<Float>{-1e10, 1e10}))
       << r.Origin() << ' ' << r.Direction();
 
   r = Ray(Point3(0, -3, 0), Vector3(0, 1, 0));
-  EXPECT_TRUE(box.isHitIn(r, Interval<double>::Positive()))
+  EXPECT_TRUE(box.isHitIn(r, Interval<Float>::Positive()))
       << r.Origin() << ' ' << r.Direction();
   r = Ray(Point3(0.5, 0.5, 3), Vector3(0, 0, -0.5));
-  EXPECT_TRUE(box.isHitIn(r, Interval<double>::Positive()))
+  EXPECT_TRUE(box.isHitIn(r, Interval<Float>::Positive()))
       << r.Origin() << ' ' << r.Direction();
 }
 
@@ -93,15 +93,15 @@ TEST_F(aabbTest, parallelRayNoHit) {
   const AABB& box = unit;
 
   Ray r(Point3(-3, 0, 1.001), Vector3(-1, 0, 0));
-  EXPECT_FALSE(box.isHitIn(r, Interval<double>::Positive()))
+  EXPECT_FALSE(box.isHitIn(r, Interval<Float>::Positive()))
       << r.Origin() << ' ' << r.Direction();
 
   r = Ray(Point3(2, -3, 1), Vector3(0, 1, 0));
-  EXPECT_FALSE(box.isHitIn(r, Interval<double>::Positive()))
+  EXPECT_FALSE(box.isHitIn(r, Interval<Float>::Positive()))
       << r.Origin() << ' ' << r.Direction();
 
   r = Ray(Point3(1.5, 0.5, 3), Vector3(0, 0, -0.5));
-  EXPECT_FALSE(box.isHitIn(r, Interval<double>::Positive()))
+  EXPECT_FALSE(box.isHitIn(r, Interval<Float>::Positive()))
       << r.Origin() << ' ' << r.Direction();
 }
 
@@ -200,7 +200,7 @@ TEST_P(aabbTransformTest, approxInsideCube) {
   std::vector<Point3> v;
   const int points_per_face = 100;
   for (int axis = 0; axis < 3; ++axis)
-    for (double i : {-1.0, 1.0})
+    for (Float i : {-1.0, 1.0})
       std::generate_n(std::back_inserter(v), points_per_face, [&axis, &i]() {
         Point3 p = (Point3)Vector3::Random(-1, 1);
         p[axis] = i;
@@ -212,7 +212,7 @@ TEST_P(aabbTransformTest, approxInsideCube) {
 TEST_P(aabbTransformTest, approxOutsideCube) {
   const int points_per_face = 100;
   for (int axis = 0; axis < 3; ++axis)
-    for (double i : {-1.01, 1.01})
+    for (Float i : {-1.01, 1.01})
       for (int cnt = 0; cnt < points_per_face; ++cnt) {
         Point3 p = (Point3)Vector3::Random(-1, 1);
         p[axis] = i;

--- a/test/aggregator-test.cpp
+++ b/test/aggregator-test.cpp
@@ -11,9 +11,9 @@
 
 class FakeShape : public IShape {
  public:
-  FakeShape(AABB box, double time) : bbox_(std::move(box)), time_(time) {}
+  FakeShape(AABB box, Float time) : bbox_(std::move(box)), time_(time) {}
 
-  HitRecord Hit(const Ray& r, const Interval<double>& interval) const override {
+  HitRecord Hit(const Ray& r, const Interval<Float>& interval) const override {
     if (time_ > 0.0 && bbox_.isHitIn(r, interval))
       return HitRecord::Create(time_, r.At(time_), Point2(0, 0),
                                Normal{0, 1, 0});
@@ -25,7 +25,7 @@ class FakeShape : public IShape {
 
  private:
   AABB bbox_;
-  double time_;
+  Float time_;
 };
 
 class AggregatorTest : public ::testing::Test {
@@ -88,7 +88,7 @@ TEST_F(AggregatorTest, hit) {
 
   for (int i = 0; i < testcases; ++i) {
     auto r = rand_ray();
-    auto t = Interval<double>::Positive();
+    auto t = Interval<Float>::Positive();
 
     auto rec = aggregator->Hit(r, t);
     auto it = std::find_if(hittables.cbegin(), hittables.cend(),
@@ -113,7 +113,7 @@ TEST_F(AggregatorTest, SingleObject) {
   aggregator = std::make_unique<BVT>(primitives);
 
   Ray r(Point3(0.5, 0.5, -1), Vector3(0, 0, 1));
-  auto rec = aggregator->Hit(r, Interval<double>::Positive());
+  auto rec = aggregator->Hit(r, Interval<Float>::Positive());
 
   ASSERT_TRUE(rec.hits);
   EXPECT_EQ(rec.primitive, obj.get());

--- a/test/common/mshape.hpp
+++ b/test/common/mshape.hpp
@@ -11,7 +11,7 @@ class mShape : public IShape {
 
   MOCK_METHOD(HitRecord,
               Hit,
-              (const Ray& r, const Interval<double>& period),
+              (const Ray& r, const Interval<Float>& period),
               (const, override));
   MOCK_METHOD(AABB, GetBbox, (), (const, override));
 };

--- a/test/dielectric-test.cpp
+++ b/test/dielectric-test.cpp
@@ -89,7 +89,7 @@ TEST_F(DielectricTest, RoughfAndpdf) {
 }
 
 TEST_F(DielectricTest, ReflectAndRefract) {
-  const double eta = 1.6;
+  const Float eta = 1.6;
   Dielectric glass(eta);
 
   int reflects = 0, refracts = 0;
@@ -107,7 +107,7 @@ TEST_F(DielectricTest, ReflectAndRefract) {
           << wi << ' ' << wo;  // theta_r = theta_i
     } else {                   // refract
       ++refracts;
-      const double e = wi.y() < 0 ? eta : 1.0 / eta;
+      const Float e = wi.y() < 0 ? eta : 1.0 / eta;
       EXPECT_NEAR(std::sqrt(1.0 - wi.y() * wi.y()),
                   e * std::sqrt(1.0 - wo.y() * wo.y()), kEps)
           << wi << ' ' << wo;
@@ -122,14 +122,14 @@ TEST_F(DielectricTest, PdfBsdfConsistency) {
   // check that
   // \int f(wi,wo)|cos(wo)| / pdf = 1
 
-  double mean = 0;
+  Float mean = 0;
   int N = 10000, valid = 0;
   for (int i = 0; i < N; ++i) {
     Vector3 wi = rand_sphere_uniform();
     if (auto s = rough.Sample_f(wi)) {
       ++valid;
 
-      double ratio = s->f[0] * AbsCosTheta(s->wo) / s->pdf;  // use red channel
+      Float ratio = s->f[0] * AbsCosTheta(s->wo) / s->pdf;  // use red channel
       mean += std::fabs(ratio - 1);
     }
   }
@@ -143,29 +143,29 @@ TEST_F(DielectricTest, PdfNormalisation) {
   // \int pdf(wi,wo) dwi = 1
 
   static constexpr int N = 10000;
-  double s = 0;
+  Float s = 0;
   Vector3 wi = Vector3(0, -1, 0) + 0.1 * rand_sphere_uniform();
   wi = wi.Normalized();
   for (int i = 0; i < N; ++i) {
     Vector3 wo = rand_sphere_uniform();
-    double pdf = rough.pdf(wi, wo);
+    Float pdf = rough.pdf(wi, wo);
     s += pdf;
   }
-  double estimate = (4 * pi) * s / N;
+  Float estimate = (4 * pi) * s / N;
   EXPECT_NEAR(estimate, 1, 0.25);
 }
 
 TEST_F(DielectricTest, EnergyConservation) {
   static constexpr int K = 32, M = 10000;
 
-  double reflected = 0, transmitted = 0;
+  Float reflected = 0, transmitted = 0;
   for (int k = 0; k < K; ++k) {  // incident directions
     Vector3 wi = Vector3(0, -1, 0) + 0.1 * rand_sphere_uniform();
     wi = wi.Normalized();
 
     for (int j = 0; j < M; ++j) {  // integrate over wo
       if (auto samp = rough.Sample_f(wi)) {
-        double cos_o = AbsCosTheta(samp->wo);
+        Float cos_o = AbsCosTheta(samp->wo);
         if (SameHemisphere(wi, samp->wo))
           reflected += samp->f[0] * cos_o / samp->pdf;
         else

--- a/test/geometry-test.cpp
+++ b/test/geometry-test.cpp
@@ -10,7 +10,7 @@
 TEST(geometryPrimitiveTest, BasicVector2) {
   Vector2 orig;
   Vector2 v1{5, -1}, v2{0.3, -1.2}, v3{10, 10};
-  const double scalar = 1.5, zero = 0;
+  const Float scalar = 1.5, zero = 0;
 
   EXPECT_DOUBLE_EQ(v1.v[0], 5.0);
   EXPECT_DOUBLE_EQ(v1.v[1], -1.0);
@@ -50,7 +50,7 @@ TEST(geometryPrimitiveTest, BasicVector3) {
   v1 = Vector3{42, -12, 4};
   v2 = Vector3{0.4, 321, 8.9};
   Vector3 i{1, 0, 0}, j{0, 1, 0}, k{0, 0, 1}, orig;
-  const double scalar = 2.5;
+  const Float scalar = 2.5;
 
   EXPECT_DOUBLE_EQ(v2[0], 0.4);
   EXPECT_DOUBLE_EQ(v2[1], 321.0);
@@ -67,7 +67,7 @@ TEST(geometryPrimitiveTest, BasicVector3) {
 }
 
 TEST(geometryPrimitiveTest, Normal) {
-  const double scale = 1.0 / pow(2.0, 1.0 / 3);
+  const Float scale = 1.0 / pow(2.0, 1.0 / 3);
   EXPECT_EQ((Normal{1, 1, 0}), (Normal{scale, scale, 0}));
 }
 

--- a/test/ggx-test.cpp
+++ b/test/ggx-test.cpp
@@ -6,7 +6,7 @@
 #include <cmath>
 #include <utility>
 
-static constexpr double EPS = 1e-5;
+static constexpr Float EPS = 1e-5;
 
 TEST(TrowbridgeReitz, D) {
   TrowbridgeReitzDistribution dist(0.5, 0.5);
@@ -83,13 +83,13 @@ TEST(TrowbridgeReitz, EffectivelySmooth) {
 }
 
 TEST(TrowbridgeReitz, RoughnessToAlpha) {
-  double r = 0.36;
+  Float r = 0.36;
   EXPECT_DOUBLE_EQ(TrowbridgeReitzDistribution::RoughnessToAlpha(r), 0.6);
 }
 
 TEST(TrowbridgeReitzDistribution, VisibleNormalPDF) {
   constexpr int N = 200'000;  // Monte-Carlo budget
-  constexpr std::tuple<double, double> roughness[] = {
+  constexpr std::tuple<Float, Float> roughness[] = {
       {0.1, 0.1}, {0.25, 0.45}, {0.5, 1.0}, {1.0, 1.0}};
 
   for (auto [ax, az] : roughness) {
@@ -99,23 +99,23 @@ TEST(TrowbridgeReitzDistribution, VisibleNormalPDF) {
 
     TrowbridgeReitzDistribution dist(ax, az);
 
-    double sum = 0.0;
-    double sum2 = 0.0;
+    Float sum = 0.0;
+    Float sum2 = 0.0;
 
     for (int i = 0; i < N; ++i) {
       const Vector3 wm = dist.Sample_wm(up);
-      const double pdf = dist.PDF(up, wm);
+      const Float pdf = dist.PDF(up, wm);
 
       ASSERT_GT(pdf, 0.0) << "PDF should never be zero or negative.";
 
-      const double inv = 1.0 / pdf;
+      const Float inv = 1.0 / pdf;
       sum += inv;
       sum2 += inv * inv;
     }
 
-    const double mean = sum / N;
-    const double var = sum2 / N - mean * mean;
-    const double se = std::sqrt(var / N);  // standard error
+    const Float mean = sum / N;
+    const Float var = sum2 / N - mean * mean;
+    const Float se = std::sqrt(var / N);  // standard error
 
     EXPECT_NEAR(mean, 2 * pi, 6 * se)
         << "ax=" << ax << "  az=" << az << "  mean=" << mean

--- a/test/interval-test.cpp
+++ b/test/interval-test.cpp
@@ -2,7 +2,7 @@
 
 #include <util/interval.hpp>
 
-constexpr double EPS = 1e-8;
+constexpr Float EPS = 1e-8;
 
 TEST(Mergeinterval, merge) {
   Interval a(-1000, 1000), b(-5, -3);

--- a/test/lambertian-test.cpp
+++ b/test/lambertian-test.cpp
@@ -52,7 +52,7 @@ TEST(LambertianTest, SampleF_IsCosineWeighted) {
   static const Normal n(0, 1, 0);
   Lambertian lambert(Color(1));
 
-  std::vector<double> cos_thetas(N, 0);
+  std::vector<Float> cos_thetas(N, 0);
   for (size_t i = 0; i < N; ++i) {
     const auto wi = rand_wi();
     auto sample = lambert.Sample_f(wi);
@@ -66,23 +66,23 @@ TEST(LambertianTest, SampleF_IsCosineWeighted) {
 
   // Compute the KS statistic D_n = max|F_emp(z) - F_theo(z)|,
   // where F_theo(z) = z^2 for z in [0,1].
-  double D = 0;
+  Float D = 0;
   for (size_t i = 0; i < N; ++i) {
-    double z = cos_thetas[i];
-    double F_emp1 = (i + 1.0) / N;               // empirical CDF just above z
-    double F_emp0 = static_cast<double>(i) / N;  // empirical CDF just below z
-    double F_theo = z * z;                       // theoretical CDF
+    Float z = cos_thetas[i];
+    Float F_emp1 = (i + 1.0) / N;               // empirical CDF just above z
+    Float F_emp0 = static_cast<Float>(i) / N;  // empirical CDF just below z
+    Float F_theo = z * z;                       // theoretical CDF
 
     D = std::max(D, std::abs(F_emp1 - F_theo));
     D = std::max(D, std::abs(F_emp0 - F_theo));
   }
 
   // Convert to the limiting statistic sqrt(n) * D_n
-  double stat = std::sqrt(N) * D;
+  Float stat = std::sqrt(N) * D;
   boost::math::kolmogorov_smirnov_distribution<> kolDist(N);
-  double K_cdf = cdf(kolDist, stat);
+  Float K_cdf = cdf(kolDist, stat);
 
-  double p_value = 1.0 - K_cdf;  // p-value = 1 - K(stat)
+  Float p_value = 1.0 - K_cdf;  // p-value = 1 - K(stat)
   EXPECT_LT(p_value, 0.01) << "p_value = " << p_value;
 }
 
@@ -93,7 +93,7 @@ TEST(LambertianTest, SampleConvergence) {
   static constexpr auto N = 64;
   Lambertian lambert(Color(1));
 
-  double Iu = 0, Icos = 0;
+  Float Iu = 0, Icos = 0;
   for (size_t i = 0; i < N; ++i) {
     auto wi = rand_wi();
     auto sample = lambert.Sample_f(wi);
@@ -105,6 +105,6 @@ TEST(LambertianTest, SampleConvergence) {
 
   Iu /= N;
   Icos /= N;
-  double err_iu = std::fabs(Iu - pi), err_icos = std::fabs(Icos - pi);
+  Float err_iu = std::fabs(Iu - pi), err_icos = std::fabs(Icos - pi);
   EXPECT_LT(err_icos, err_iu) << "errors are: " << err_icos << " vs " << err_iu;
 }

--- a/test/mapping-test.cpp
+++ b/test/mapping-test.cpp
@@ -13,7 +13,7 @@ class SphericalMapTest
 
   inline static constexpr int N = 16;
   static auto from_st(Point2 st) -> Vector3 {
-    double theta = st.y() * pi, phi = (st.x() - 0.5) * 2 * pi;
+    Float theta = st.y() * pi, phi = (st.x() - 0.5) * 2 * pi;
     return Vector3(std::sin(theta) * std::cos(phi), std::cos(theta),
                    std::sin(theta) * std::sin(phi));
   }

--- a/test/shape/plane-test.cpp
+++ b/test/shape/plane-test.cpp
@@ -16,7 +16,7 @@ class PlaneTest : public ::testing::Test {
   inline static constexpr int N = 8;
   inline static constexpr auto EPS = 1e-6;
 
-  static inline Point3 rand_point(double min = -10, double max = 10) {
+  static inline Point3 rand_point(Float min = -10, Float max = 10) {
     return Point3(random_double(min, max), random_double(min, max),
                   random_double(min, max));
   }
@@ -25,7 +25,7 @@ class PlaneTest : public ::testing::Test {
   Vector3 e1 = a - o, e2 = b - o;
   std::unique_ptr<T> shape = std::make_unique<T>(o, a, b);
 
-  double u, v;
+  Float u, v;
 
   Point3 rand_on_plane() {
     if constexpr (std::same_as<T, Triangle>) {
@@ -74,10 +74,10 @@ TYPED_TEST(PlaneTest, Bbox) {
 }
 
 TYPED_TEST(PlaneTest, RayHit) {
-  static const Interval<double> unit(0, 1);
+  static const Interval<Float> unit(0, 1);
 
   Point3 on_plane, ray_point;
-  double time;
+  Float time;
   Ray r;
 
   for (int i = 0; i < this->N; ++i) {
@@ -87,14 +87,14 @@ TYPED_TEST(PlaneTest, RayHit) {
     time = r.direction.Length();
     r.direction /= time;
 
-    HitRecord rec = this->shape->Hit(r, Interval<double>::Positive());
+    HitRecord rec = this->shape->Hit(r, Interval<Float>::Positive());
     EXPECT_TRUE(rec.hits) << this->o << ' ' << this->a << ' ' << this->b << '\n'
                           << r;
     EXPECT_NEAR(rec.time, time, this->EPS);
     EXPECT_EQ(rec.position, on_plane);
     Normal n = rec.normal;
     EXPECT_TRUE(IsPerpendicular(n, this->e1) && IsPerpendicular(n, this->e2));
-    double u = this->u, v = this->v;
+    Float u = this->u, v = this->v;
     EXPECT_TRUE(unit.Contains(rec.uv.x()) && unit.Contains(rec.uv.y()))
         << rec.uv;
     EXPECT_EQ(rec.uv, Point2(u - std::floor(u), v - std::floor(v)));
@@ -103,7 +103,7 @@ TYPED_TEST(PlaneTest, RayHit) {
 
 TYPED_TEST(PlaneTest, HitOutsideInterval) {
   Point3 on_plane, ray_point;
-  double time;
+  Float time;
   Ray r;
 
   for (int i = 0; i < this->N; ++i) {
@@ -113,7 +113,7 @@ TYPED_TEST(PlaneTest, HitOutsideInterval) {
     time = r.direction.Length();
     r.direction /= time;
 
-    auto rec = this->shape->Hit(r, Interval<double>(0, time - this->EPS));
+    auto rec = this->shape->Hit(r, Interval<Float>(0, time - this->EPS));
     ASSERT_FALSE(rec.hits);
   }
 }
@@ -127,7 +127,7 @@ TYPED_TEST(PlaneTest, NoHit) {
     Point3 ray_point = this->rand_point();
     Ray r(ray_point, (*off_plane - ray_point).Normalized());
 
-    auto rec = this->shape->Hit(r, Interval<double>::Positive());
+    auto rec = this->shape->Hit(r, Interval<Float>::Positive());
     EXPECT_FALSE(rec.hits);
   }
 }
@@ -138,7 +138,7 @@ TYPED_TEST(PlaneTest, parallelRayNoHit) {
         random_uniform_01() * this->e1 + random_uniform_01() * this->e2;
     Ray r(this->rand_point(), parallel.Normalized());
 
-    auto rec = this->shape->Hit(r, Interval<double>::Universe());
+    auto rec = this->shape->Hit(r, Interval<Float>::Universe());
     EXPECT_FALSE(rec.hits);
   }
 }

--- a/test/shape/sphere-test.cpp
+++ b/test/shape/sphere-test.cpp
@@ -13,7 +13,7 @@ class SphereTest : public ::testing::Test {
   inline static constexpr int N = 64;
   inline static constexpr auto EPS = 1e-6;
 
-  static Point3 rand_point(double min = -10, double max = 10) {
+  static Point3 rand_point(Float min = -10, Float max = 10) {
     return Point3(random_double(min, max), random_double(min, max),
                   random_double(min, max));
   }
@@ -26,7 +26,7 @@ class SphereTest : public ::testing::Test {
 
   Sphere unit_sphere;
   Point3 o;
-  double r;
+  Float r;
   Sphere rand_sphere;
 };
 
@@ -45,7 +45,7 @@ TEST_F(SphereTest, Area) {
 }
 
 static auto from_uv(Point2 uv) -> Vector3 {
-  double theta = uv.y() * pi, phi = (uv.x() - 0.5) * 2 * pi;
+  Float theta = uv.y() * pi, phi = (uv.x() - 0.5) * 2 * pi;
   return Vector3(std::sin(theta) * std::cos(phi), std::cos(theta),
                  std::sin(theta) * std::sin(phi));
 }
@@ -63,7 +63,7 @@ TEST_F(SphereTest, Uv) {
 }
 
 TEST_F(SphereTest, UvEdgeCase) {
-  static const Interval<double> unit(0, 1);
+  static const Interval<Float> unit(0, 1);
 
   for (int i = -1; i <= 1; ++i)
     for (int j = -1; j <= 1; ++j)
@@ -86,7 +86,7 @@ TEST_F(SphereTest, RayHits) {
   Point3 on_sphere, ray_point;
   HitRecord rec;
   Ray r;
-  double time;
+  Float time;
 
   for (auto* sphere : std::to_array<Sphere*>({&unit_sphere, &rand_sphere})) {
     for (int i = 0; i < N; ++i) {
@@ -97,7 +97,7 @@ TEST_F(SphereTest, RayHits) {
       time = r.direction.Length();
       r.direction /= time;
 
-      rec = sphere->Hit(r, Interval<double>::Positive());
+      rec = sphere->Hit(r, Interval<Float>::Positive());
       EXPECT_TRUE(rec.hits) << ray_point << ' ' << on_sphere;
       EXPECT_NEAR(rec.time, time, EPS);
 
@@ -109,7 +109,7 @@ TEST_F(SphereTest, RayHits) {
       time = r.direction.Length();
       r.direction /= time;
 
-      rec = sphere->Hit(r, Interval<double>::Positive());
+      rec = sphere->Hit(r, Interval<Float>::Positive());
       EXPECT_TRUE(rec.hits) << ray_point << ' ' << on_sphere;
       EXPECT_NEAR(rec.time, time, EPS);
     }
@@ -120,7 +120,7 @@ TEST_F(SphereTest, HitOutsideTimeInterval) {
   Point3 on_sphere, ray_point;
   HitRecord rec;
   Ray r;
-  double time;
+  Float time;
 
   for (auto* sphere : std::to_array<Sphere*>({&unit_sphere, &rand_sphere})) {
     for (int i = 0; i < N; ++i) {
@@ -131,7 +131,7 @@ TEST_F(SphereTest, HitOutsideTimeInterval) {
       time = r.direction.Length();
       r.direction /= time;
 
-      rec = sphere->Hit(r, Interval<double>(0, time - EPS));
+      rec = sphere->Hit(r, Interval<Float>(0, time - EPS));
       EXPECT_FALSE(rec.hits) << ray_point << ' ' << on_sphere;
 
       // outside
@@ -142,7 +142,7 @@ TEST_F(SphereTest, HitOutsideTimeInterval) {
       time = r.direction.Length();
       r.direction /= time;
 
-      rec = sphere->Hit(r, Interval<double>(0, time - EPS));
+      rec = sphere->Hit(r, Interval<Float>(0, time - EPS));
       EXPECT_FALSE(rec.hits) << ray_point << ' ' << on_sphere;
     }
   }
@@ -157,7 +157,7 @@ TEST_F(SphereTest, Nohit) {
       vp = sphere->GetTransformation().Doit(vp);
 
       Ray r = Ray(p - vp, vp);
-      auto rec = sphere->Hit(r, Interval<double>::Universe());
+      auto rec = sphere->Hit(r, Interval<Float>::Universe());
       EXPECT_FALSE(rec.hits) << r;
     }
   }

--- a/test/transform-test.cpp
+++ b/test/transform-test.cpp
@@ -132,7 +132,7 @@ TYPED_TEST(ScalingTest, Normals) {
 template <class rotate_t>
 class RotateTest : public TransformTest {
  public:
-  decltype(auto) axisTr(basic_vector<double, 3> n, double angle) {
+  decltype(auto) axisTr(basic_vector<Float, 3> n, Float angle) {
     return std::make_shared<rotate_t>(std::move(rotate_t::Rotate(n, angle)));
   }
 
@@ -151,7 +151,7 @@ TYPED_TEST_SUITE(RotateTest, rotate_impl);
 TYPED_TEST(RotateTest, simpleAxis) {
   Vector3 v{1, 0, 0};
   Normal n{0, 1, 0};
-  double angle = pi / 2;
+  Float angle = pi / 2;
   auto tr = this->axisTr(n, angle);
   EXPECT_EQ(tr->Doit(v), Vector3(0, 0, 1));
 
@@ -165,7 +165,7 @@ TYPED_TEST(RotateTest, simpleAxis) {
 TYPED_TEST(RotateTest, diagonalAxis) {
   Vector3 v{0, 1, 0};
   Normal n{1, 1, 1};
-  double angle = 120.0 / 180 * pi;
+  Float angle = 120.0 / 180 * pi;
   auto tr = this->axisTr(n, angle);
   EXPECT_EQ(tr->Doit(v), Vector3(1, 0, 0));
 }
@@ -173,7 +173,7 @@ TYPED_TEST(RotateTest, diagonalAxis) {
 TYPED_TEST(RotateTest, smallAngleAxis) {
   Vector3 v{1, 1, 1};
   Normal n{1, 0, 0};
-  double angle = 10.0 / 180 * pi;
+  Float angle = 10.0 / 180 * pi;
   auto tr = this->axisTr(n, angle);
   EXPECT_EQ(tr->Doit(v), Vector3(1, 1.15845593, 0.81115958));
 }
@@ -185,7 +185,7 @@ TYPED_TEST(RotateTest, zeroVector) {
                   random_uniform_01()};
   };
   auto n = randNormal(), np = randNormal();
-  double angle = pi * 2 * random_uniform_01();
+  Float angle = pi * 2 * random_uniform_01();
   auto tr = this->axisTr(n, angle);
   EXPECT_EQ(tr->Doit(v), v);
 
@@ -196,7 +196,7 @@ TYPED_TEST(RotateTest, zeroVector) {
 TYPED_TEST(RotateTest, rotate180DegAxis) {
   Vector3 v1{random_uniform_01(), 0, 0}, v2{0, 0, 0};
   Normal n{0, 1, 0};
-  double angle = pi;
+  Float angle = pi;
   auto tr = this->axisTr(n, angle);
   EXPECT_EQ(tr->Doit(v1), -v1);
   EXPECT_EQ(tr->Doit(v2), v2);
@@ -298,7 +298,7 @@ TEST(MatTransformationTest, rotateXyzAxis) {
   EXPECT_NEAR(vp.z(), -8.3826, 0.05);
 }
 
-inline static Vector3 randvec(double k = 1000) {
+inline static Vector3 randvec(Float k = 1000) {
   return Vector3{random_double(-k, k), random_double(-k, k),
                  random_double(-k, k)};
 }
@@ -330,7 +330,7 @@ TEST(MatTransformationTest, Affine) {
   Vector3 u = randvec(k), v = randvec(k);
   auto trans = MatrixTransformation::ChangeCoordinate(o1, o1 + u, o1 + v);
 
-  double a = random_double(-k, k), b = random_double(-k, k);
+  Float a = random_double(-k, k), b = random_double(-k, k);
   Point3 p1 = o1 + a * u + b * v;
 
   Point3 p = trans.Undo(p1);


### PR DESCRIPTION
## Summary
- add new header `prshdefs.hpp` defining `Float`
- use `Float` type alias across renderer and tests
- expose constants (`infinity`, `pi`, `invpi`) in new `Float` precision

## Testing
- `cmake .. -DBUILD_TESTING=OFF` *(fails: missing external library CMake files)*

------
https://chatgpt.com/codex/tasks/task_e_6857465fbb288324be6b88ba4546b0fa